### PR TITLE
544 table export

### DIFF
--- a/.changeset/eight-wolves-rhyme.md
+++ b/.changeset/eight-wolves-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": minor
+---
+
+544 - Export functionality for the tables

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,5 +5,9 @@
 packages/*/CHANGELOG.md
 /coverage
 /mkdocs
+
+/.changeset/*.md
+!/.changeset/README.md
+
 .next
 node_modules

--- a/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
@@ -37,7 +37,10 @@ import {
     getQueryVariablesForExport,
     parseDateToLocaleDateTimeString,
 } from '@/utils';
-import { csvDownloadHandler } from '@/utils/csvDownload';
+import {
+    csvDownloadHandler,
+    getCsvFileNameWithDate,
+} from '@/utils/csvDownload';
 
 import {
     graphQlProcessFilterMapper,
@@ -252,7 +255,7 @@ export const WfoProcessesList = ({
                 getProcessListForExport,
                 mapGraphQlProcessListResultToProcessListItems,
                 mapGraphQlProcessListResultToPageInfo,
-                'Processes.csv',
+                getCsvFileNameWithDate('Processes'),
                 addToast,
                 tError,
             )}

--- a/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
@@ -255,6 +255,7 @@ export const WfoProcessesList = ({
                 getProcessListForExport,
                 mapGraphQlProcessListResultToProcessListItems,
                 mapGraphQlProcessListResultToPageInfo,
+                Object.keys(tableColumns),
                 getCsvFileNameWithDate('Processes'),
                 addToast,
                 tError,

--- a/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
@@ -29,6 +29,7 @@ import {
     DataDisplayParams,
     useQueryWithGraphql,
     useQueryWithGraphqlLazy,
+    useToastMessage,
 } from '@/hooks';
 import { WfoProcessListSubscriptionsCell } from '@/pages';
 import { GraphqlQueryVariables, Process, SortOrder } from '@/types';
@@ -41,6 +42,7 @@ import { csvDownloadHandler } from '@/utils/csvDownload';
 import {
     graphQlProcessFilterMapper,
     graphQlProcessSortMapper,
+    mapGraphQlProcessListResultToPageInfo,
     mapGraphQlProcessListResultToProcessListItems,
 } from './processListObjectMappers';
 
@@ -88,6 +90,8 @@ export const WfoProcessesList = ({
     overrideDefaultTableColumns,
 }: WfoProcessesListProps) => {
     const t = useTranslations('processes.index');
+    const tError = useTranslations('errors');
+    const { addToast } = useToastMessage();
 
     const defaultTableColumns: WfoTableColumns<ProcessListItem> = {
         workflowName: {
@@ -247,7 +251,10 @@ export const WfoProcessesList = ({
             onExportData={csvDownloadHandler(
                 getProcessListForExport,
                 mapGraphQlProcessListResultToProcessListItems,
+                mapGraphQlProcessListResultToPageInfo,
                 'Processes.csv',
+                addToast,
+                tError,
             )}
             exportDataIsLoading={isFetchingCsv}
         />

--- a/packages/orchestrator-ui-components/src/components/WfoProcessList/processListObjectMappers.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoProcessList/processListObjectMappers.ts
@@ -6,6 +6,10 @@ import {
 } from '../../types';
 import { ProcessListItem } from './WfoProcessesList';
 
+export const mapGraphQlProcessListResultToPageInfo = (
+    processesResult: ProcessListResult,
+) => processesResult.processes.pageInfo;
+
 export const mapGraphQlProcessListResultToProcessListItems = (
     processesResult: ProcessListResult,
 ): ProcessListItem[] =>

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
@@ -24,7 +24,7 @@ import {
     getTypedFieldFromObject,
     parseDateToLocaleDateTimeString,
 } from '@/utils';
-import { initiateCsvFileDownload } from '@/utils/csvDownload';
+import { csvDownloadHandler } from '@/utils/csvDownload';
 
 import {
     DEFAULT_PAGE_SIZES,
@@ -179,23 +179,6 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
         totalItemCount: totalItems ?? 0,
     };
 
-    const handleCsvDownload = async () => {
-        const subscriptionListForExportGraphqlResult =
-            await getSubscriptionListForExport();
-
-        if (subscriptionListForExportGraphqlResult) {
-            const subscriptionListForExport =
-                mapGraphQlSubscriptionsResultToSubscriptionListItems(
-                    subscriptionListForExportGraphqlResult,
-                );
-
-            initiateCsvFileDownload(
-                subscriptionListForExport,
-                'subscriptions.csv',
-            );
-        }
-    };
-
     return (
         <WfoTableWithFilter<SubscriptionListItem>
             queryString={dataDisplayParams.queryString}
@@ -225,7 +208,11 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
                 setDataDisplayParam,
             )}
             hasError={isError}
-            onExportData={handleCsvDownload}
+            onExportData={csvDownloadHandler(
+                getSubscriptionListForExport,
+                mapGraphQlSubscriptionsResultToSubscriptionListItems,
+                'Subscriptions.csv',
+            )}
             exportDataIsLoading={isFetchingCsv}
         />
     );

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
@@ -25,7 +25,10 @@ import {
     getTypedFieldFromObject,
     parseDateToLocaleDateTimeString,
 } from '@/utils';
-import { csvDownloadHandler } from '@/utils/csvDownload';
+import {
+    csvDownloadHandler,
+    getCsvFileNameWithDate,
+} from '@/utils/csvDownload';
 
 import {
     DEFAULT_PAGE_SIZES,
@@ -216,7 +219,7 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
                 getSubscriptionListForExport,
                 mapGraphQlSubscriptionsResultToSubscriptionListItems,
                 mapGraphQlSubscriptionsResultToPageInfo,
-                'Subscriptions.csv',
+                getCsvFileNameWithDate('Subscriptions'),
                 addToast,
                 tError,
             )}

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
@@ -183,9 +183,36 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
     };
 
     const handleCsvDownload = async () => {
-        console.log('Start downloading csv');
-        const result = await getSubscriptionListForCsvExport();
-        console.log('Done fetching, RAW data:', { result });
+        const subscriptionListForExportGraphqlResult =
+            await getSubscriptionListForCsvExport();
+
+        if (subscriptionListForExportGraphqlResult) {
+            const subscriptionListForExport =
+                mapGraphQlSubscriptionsResultToSubscriptionListItems(
+                    subscriptionListForExportGraphqlResult,
+                );
+
+            const headers = Object.keys(subscriptionListForExport[0]).join(';');
+            const rows = subscriptionListForExport.map((row) =>
+                Object.values(row)
+                    .map((value) => (value === null ? '' : `"${value}"`))
+                    .join(';')
+                    .split('\n')
+                    .join(' '),
+            );
+            const csv = [headers, ...rows].join('\n');
+
+            // Triggering download
+            const blob = new Blob([csv], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'data.csv'; // todo come up with a better name
+            link.click();
+            URL.revokeObjectURL(url);
+        } else {
+            console.error('No data to download');
+        }
     };
 
     return (

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
@@ -18,8 +18,9 @@ import {
     useQueryWithGraphql,
     useQueryWithGraphqlLazy,
 } from '@/hooks';
-import { SortOrder } from '@/types';
+import { GraphqlQueryVariables, SortOrder } from '@/types';
 import {
+    getQueryVariablesForExport,
     getTypedFieldFromObject,
     parseDateToLocaleDateTimeString,
 } from '@/utils';
@@ -138,29 +139,24 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
         },
     };
 
-    const { sortBy, queryString } = dataDisplayParams;
+    const { sortBy, queryString, pageIndex, pageSize } = dataDisplayParams;
+
+    const graphqlQueryVariables: GraphqlQueryVariables<SubscriptionListItem> = {
+        first: pageSize,
+        after: pageIndex * pageSize,
+        sortBy,
+        filterBy: alwaysOnFilters,
+        query: queryString || undefined,
+    };
     const { data, isError, isLoading } = useQueryWithGraphql(
         getSubscriptionsListGraphQlQuery<SubscriptionListItem>(),
-        {
-            first: dataDisplayParams.pageSize,
-            after: dataDisplayParams.pageIndex * dataDisplayParams.pageSize,
-            sortBy,
-            filterBy: alwaysOnFilters,
-            query: queryString || undefined,
-        },
+        graphqlQueryVariables,
         ['subscriptions', 'listPage'],
     );
-
     const { getData: getSubscriptionListForExport, isFetching: isFetchingCsv } =
         useQueryWithGraphqlLazy(
             getSubscriptionsListGraphQlQuery<SubscriptionListItem>(),
-            {
-                first: 1000,
-                after: 0,
-                sortBy: dataDisplayParams.sortBy,
-                filterBy: alwaysOnFilters,
-                query: dataDisplayParams.queryString || undefined,
-            },
+            getQueryVariablesForExport(graphqlQueryVariables),
             ['subscriptions', 'export'],
         );
 

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
@@ -219,6 +219,7 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
                 getSubscriptionListForExport,
                 mapGraphQlSubscriptionsResultToSubscriptionListItems,
                 mapGraphQlSubscriptionsResultToPageInfo,
+                Object.keys(tableColumns),
                 getCsvFileNameWithDate('Subscriptions'),
                 addToast,
                 tError,

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
@@ -17,6 +17,7 @@ import {
     DataDisplayParams,
     useQueryWithGraphql,
     useQueryWithGraphqlLazy,
+    useToastMessage,
 } from '@/hooks';
 import { GraphqlQueryVariables, SortOrder } from '@/types';
 import {
@@ -41,8 +42,9 @@ import { WfoFirstPartUUID } from '../WfoTable/WfoFirstPartUUID';
 import { mapSortableAndFilterableValuesToTableColumnConfig } from '../WfoTable/utils/mapSortableAndFilterableValuesToTableColumnConfig';
 import {
     SubscriptionListItem,
+    mapGraphQlSubscriptionsResultToPageInfo,
     mapGraphQlSubscriptionsResultToSubscriptionListItems,
-} from './mapGraphQlSubscriptionsResultToSubscriptionListItems';
+} from './subscriptionResultMappers';
 
 export type WfoSubscriptionsListProps = {
     alwaysOnFilters?: FilterQuery<SubscriptionListItem>[];
@@ -67,6 +69,8 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
 
     const router = useRouter();
     const t = useTranslations('subscriptions.index');
+    const tError = useTranslations('errors');
+    const { addToast } = useToastMessage();
 
     const tableColumns: WfoTableColumns<SubscriptionListItem> = {
         subscriptionId: {
@@ -211,7 +215,10 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
             onExportData={csvDownloadHandler(
                 getSubscriptionListForExport,
                 mapGraphQlSubscriptionsResultToSubscriptionListItems,
+                mapGraphQlSubscriptionsResultToPageInfo,
                 'Subscriptions.csv',
+                addToast,
+                tError,
             )}
             exportDataIsLoading={isFetchingCsv}
         />

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
@@ -13,7 +13,11 @@ import {
     WfoSubscriptionStatusBadge,
 } from '@/components';
 import { getSubscriptionsListGraphQlQuery } from '@/graphqlQueries';
-import { DataDisplayParams, useQueryWithGraphql } from '@/hooks';
+import {
+    DataDisplayParams,
+    useQueryWithGraphql,
+    useQueryWithGraphqlLazy,
+} from '@/hooks';
 import { SortOrder } from '@/types';
 import {
     getTypedFieldFromObject,
@@ -146,6 +150,19 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
         ['subscriptions', 'listPage'],
     );
 
+    const { getData: getSubscriptionListForCsvExport } =
+        useQueryWithGraphqlLazy(
+            getSubscriptionsListGraphQlQuery<SubscriptionListItem>(),
+            {
+                first: 1000,
+                after: 0,
+                sortBy: dataDisplayParams.sortBy,
+                filterBy: alwaysOnFilters,
+                query: dataDisplayParams.queryString || undefined,
+            },
+            ['subscriptions', 'csv'],
+        );
+
     const sortedColumnId = getTypedFieldFromObject(sortBy?.field, tableColumns);
     if (!sortedColumnId) {
         router.replace('/subscriptions');
@@ -165,7 +182,11 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
         totalItemCount: totalItems ?? 0,
     };
 
-    const handleCsvDownload = () => {};
+    const handleCsvDownload = async () => {
+        console.log('Start downloading csv');
+        const result = await getSubscriptionListForCsvExport();
+        console.log('Done fetching, RAW data:', { result });
+    };
 
     return (
         <WfoTableWithFilter<SubscriptionListItem>
@@ -199,50 +220,4 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
             onDownloadCsv={() => handleCsvDownload()}
         />
     );
-};
-
-//todo move out of here to make it reusable
-type WfoCsvDownloaderProps = {
-    alwaysOnFilters?: FilterQuery<SubscriptionListItem>[];
-    dataDisplayParams: DataDisplayParams<SubscriptionListItem>;
-};
-
-// A component is used since we are using a hook to fetch the data
-// Might be better to split up the hook from the actual data fetching (useQueryWithGraphql.ts)
-const WfoCsvDownloader: FC<WfoCsvDownloaderProps> = ({
-    alwaysOnFilters,
-    dataDisplayParams,
-}) => {
-    const { data, isLoading } = useQueryWithGraphql(
-        getSubscriptionsListGraphQlQuery<SubscriptionListItem>(),
-        {
-            first: 1000,
-            after: 0,
-            sortBy: dataDisplayParams.sortBy,
-            filterBy: alwaysOnFilters,
-            query: dataDisplayParams.queryString || undefined,
-        },
-        'subscriptions',
-    );
-
-    if (isLoading) {
-        return <div>Loading CSV...</div>;
-    }
-
-    const dataForCsv = data?.subscriptions.page;
-    console.log('CSV data', dataForCsv);
-
-    // inspiration https://openjavascript.info/2022/12/18/json-file-to-csv-download-with-vanilla-javascript/
-    // Note: Some fields are objects and .toString() doesn't work well on them
-    // we need to parse the data just like we do in the table.
-
-    if (dataForCsv) {
-        const headers = Object.keys(dataForCsv[0]).toString();
-        const rows = dataForCsv.map((row) => Object.values(row).toString());
-        const csv = [headers, ...rows].join('\n');
-
-        console.log({ csv });
-    }
-
-    return <div>CSV is Ready</div>;
 };

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/index.ts
@@ -1,3 +1,3 @@
-export * from './mapGraphQlSubscriptionsResultToSubscriptionListItems';
+export * from './subscriptionResultMappers';
 export * from './subscriptionListTabs';
 export * from './WfoSubscriptionsList';

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/subscriptionListTabs.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/subscriptionListTabs.ts
@@ -1,5 +1,5 @@
 import { WfoFilterTab } from '../../components';
-import { SubscriptionListItem } from './mapGraphQlSubscriptionsResultToSubscriptionListItems';
+import { SubscriptionListItem } from './subscriptionResultMappers';
 
 export enum WfoSubscriptionListTab {
     ACTIVE = 'ACTIVE',

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/subscriptionResultMappers.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/subscriptionResultMappers.ts
@@ -13,6 +13,12 @@ export type SubscriptionListItem = Pick<
     customerShortcode: string;
 };
 
+export function mapGraphQlSubscriptionsResultToPageInfo(
+    graphqlResponse: SubscriptionsResult,
+) {
+    return graphqlResponse.subscriptions.pageInfo;
+}
+
 export function mapGraphQlSubscriptionsResultToSubscriptionListItems(
     graphqlResponse: SubscriptionsResult,
 ): SubscriptionListItem[] {

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableWithFilter/WfoTableWithFilter.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableWithFilter/WfoTableWithFilter.tsx
@@ -62,7 +62,8 @@ export type WfoTableWithFilterProps<T extends object> = {
     onUpdatePage: (criterion: Criteria<T>['page']) => void;
     onUpdateDataSort: (dataSorting: WfoDataSorting<T>) => void;
     hasError?: boolean;
-    onDownloadCsv?: () => void;
+    onExportData?: () => void;
+    exportDataIsLoading?: boolean;
 };
 
 export const WfoTableWithFilter = <T extends object>({
@@ -82,7 +83,8 @@ export const WfoTableWithFilter = <T extends object>({
     onUpdatePage,
     onUpdateDataSort,
     hasError = false,
-    onDownloadCsv,
+    onExportData,
+    exportDataIsLoading = false,
 }: WfoTableWithFilterProps<T>) => {
     const { theme } = useOrchestratorTheme();
 
@@ -210,9 +212,13 @@ export const WfoTableWithFilter = <T extends object>({
                 <EuiButton onClick={() => setShowSettingsModal(true)}>
                     {t('editColumns')}
                 </EuiButton>
-                {onDownloadCsv && (
-                    <EuiButton onClick={() => onDownloadCsv()}>
-                        {'CSV'}
+                {onExportData && (
+                    <EuiButton
+                        isLoading={exportDataIsLoading}
+                        onClick={() => onExportData()}
+                    >
+                        {/* Todo add translations */}
+                        {'Export'}
                     </EuiButton>
                 )}
             </EuiFlexGroup>

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableWithFilter/WfoTableWithFilter.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableWithFilter/WfoTableWithFilter.tsx
@@ -217,8 +217,7 @@ export const WfoTableWithFilter = <T extends object>({
                         isLoading={exportDataIsLoading}
                         onClick={() => onExportData()}
                     >
-                        {/* Todo add translations */}
-                        {'Export'}
+                        {t('export')}
                     </EuiButton>
                 )}
             </EuiFlexGroup>

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableWithFilter/WfoTableWithFilter.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableWithFilter/WfoTableWithFilter.tsx
@@ -62,6 +62,7 @@ export type WfoTableWithFilterProps<T extends object> = {
     onUpdatePage: (criterion: Criteria<T>['page']) => void;
     onUpdateDataSort: (dataSorting: WfoDataSorting<T>) => void;
     hasError?: boolean;
+    onDownloadCsv?: () => void;
 };
 
 export const WfoTableWithFilter = <T extends object>({
@@ -81,6 +82,7 @@ export const WfoTableWithFilter = <T extends object>({
     onUpdatePage,
     onUpdateDataSort,
     hasError = false,
+    onDownloadCsv,
 }: WfoTableWithFilterProps<T>) => {
     const { theme } = useOrchestratorTheme();
 
@@ -208,6 +210,11 @@ export const WfoTableWithFilter = <T extends object>({
                 <EuiButton onClick={() => setShowSettingsModal(true)}>
                     {t('editColumns')}
                 </EuiButton>
+                {onDownloadCsv && (
+                    <EuiButton onClick={() => onDownloadCsv()}>
+                        {'CSV'}
+                    </EuiButton>
+                )}
             </EuiFlexGroup>
             <EuiSpacer size="m" />
             <WfoBasicTable

--- a/packages/orchestrator-ui-components/src/configuration/constants.ts
+++ b/packages/orchestrator-ui-components/src/configuration/constants.ts
@@ -1,0 +1,1 @@
+export const MAXIMUM_ITEMS_FOR_BULK_FETCHING = 1000;

--- a/packages/orchestrator-ui-components/src/hooks/useQueryWithGraphql.ts
+++ b/packages/orchestrator-ui-components/src/hooks/useQueryWithGraphql.ts
@@ -67,5 +67,6 @@ export const useQueryWithGraphqlLazy = <U, V extends Variables>(
             const result = await queryWithGraphql.refetch();
             return result.data;
         },
+        ...queryWithGraphql,
     };
 };

--- a/packages/orchestrator-ui-components/src/hooks/useQueryWithGraphql.ts
+++ b/packages/orchestrator-ui-components/src/hooks/useQueryWithGraphql.ts
@@ -48,3 +48,24 @@ export const useQueryWithGraphql = <U, V extends Variables>(
     }
     return restWithoutError;
 };
+
+export const useQueryWithGraphqlLazy = <U, V extends Variables>(
+    query: TypedDocumentNode<U, V>,
+    queryVars: V,
+    cacheKeys: string[] | string,
+    options: UseQueryOptions<U> = {},
+) => {
+    // Disabling the query prevent the initial fetch
+    const queryWithGraphql = useQueryWithGraphql(query, queryVars, cacheKeys, {
+        ...options,
+        enabled: false,
+    });
+
+    // Calling getData fetches the data
+    return {
+        getData: async () => {
+            const result = await queryWithGraphql.refetch();
+            return result.data;
+        },
+    };
+};

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -23,7 +23,8 @@
         "newTask": "New task",
         "noFailedTasks": "No failed tasks!",
         "search": "Search",
-        "errorMessage": "An error occurred"
+        "errorMessage": "An error occurred",
+        "export": "Export"
     },
     "confirmationDialog": {
         "title": "Please confirm",

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -39,6 +39,8 @@
         "start_workflow_title": "Start workflow"
     },
     "errors": {
+        "notAllResultsExported": "The current query returned {totalResults} results. Only the first {maximumExportedResults} rows will be exported",
+        "notAllResultsExportedTitle": "Not all items exported",
         "invalidQueryParts": "The query contains invalid parts",
         "notAllowedWhenEngineIsNotRunningMessage": "This action is not allowed when the Workflow Engine is not running",
         "notAllowedWhenEngineIsNotRunningTitle": "Workflow Engine is not running",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -39,6 +39,8 @@
         "start_workflow_title": "Start workflow"
     },
     "errors": {
+        "notAllResultsExported": "De huidige query resulteert in {totalResults} resultaten. Alleen de eerste {maximumExportedResults} resultaten worden geexporteerd",
+        "notAllResultsExportedTitle": "Niet alle items geexporteerd",
         "invalidQueryParts": "De query bevat ongeldige onderdelen",
         "notAllowedWhenEngineIsNotRunningMessage": "Deze actie is niet toegestaan als de Workflow Engine niet is gestart.",
         "notAllowedWhenEngineIsNotRunningTitle": "Workflow Engine is niet gestart.",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -23,7 +23,8 @@
         "newTask": "Nieuwe task",
         "noFailedTasks": "Geen gefaalde taken!",
         "search": "Zoeken",
-        "errorMessage": "Er is een fout opgetreden"
+        "errorMessage": "Er is een fout opgetreden",
+        "export": "Exporteren"
     },
     "confirmationDialog": {
         "title": "Graag bevestigen",

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
@@ -259,6 +259,7 @@ export const WfoProductBlocksPage = () => {
                     getProductBlocksForExport,
                     (data) => data.productBlocks.page,
                     (data) => data.productBlocks.pageInfo,
+                    Object.keys(tableColumns),
                     getCsvFileNameWithDate('ProductBlocks'),
                     addToast,
                     tError,

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
@@ -34,6 +34,7 @@ import {
     useQueryWithGraphql,
     useQueryWithGraphqlLazy,
     useStoredTableConfig,
+    useToastMessage,
 } from '../../hooks';
 import type {
     GraphqlQueryVariables,
@@ -64,6 +65,8 @@ const PRODUCT_BLOCK_FIELD_PRODUCT_BLOCKS: keyof ProductBlockDefinition =
 
 export const WfoProductBlocksPage = () => {
     const t = useTranslations('metadata.productBlocks');
+    const tError = useTranslations('errors');
+    const { addToast } = useToastMessage();
 
     const [tableDefaults, setTableDefaults] =
         useState<StoredTableConfig<ProductBlockDefinition>>();
@@ -252,7 +255,10 @@ export const WfoProductBlocksPage = () => {
                 onExportData={csvDownloadHandler(
                     getProductBlocksForExport,
                     (data) => data.productBlocks.page,
+                    (data) => data.productBlocks.pageInfo,
                     'ProductBlocks.csv',
+                    addToast,
+                    tError,
                 )}
                 exportDataIsLoading={isFetchingCsv}
             />

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
@@ -5,7 +5,10 @@ import { useTranslations } from 'next-intl';
 import { EuiBadgeGroup } from '@elastic/eui';
 import type { Pagination } from '@elastic/eui/src/components';
 
-import { csvDownloadHandler } from '@/utils/csvDownload';
+import {
+    csvDownloadHandler,
+    getCsvFileNameWithDate,
+} from '@/utils/csvDownload';
 
 import {
     DEFAULT_PAGE_SIZE,
@@ -256,7 +259,7 @@ export const WfoProductBlocksPage = () => {
                     getProductBlocksForExport,
                     (data) => data.productBlocks.page,
                     (data) => data.productBlocks.pageInfo,
-                    'ProductBlocks.csv',
+                    getCsvFileNameWithDate('ProductBlocks'),
                     addToast,
                     tError,
                 )}

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
@@ -226,6 +226,7 @@ export const WfoProductsPage = () => {
                     getProductsForExport,
                     (data) => data.products.page,
                     (data) => data.products.pageInfo,
+                    Object.keys(tableColumns),
                     getCsvFileNameWithDate('Products'),
                     addToast,
                     tError,

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
@@ -35,7 +35,10 @@ import {
     parseDateToLocaleDateTimeString,
     parseIsoString,
 } from '@/utils';
-import { csvDownloadHandler } from '@/utils/csvDownload';
+import {
+    csvDownloadHandler,
+    getCsvFileNameWithDate,
+} from '@/utils/csvDownload';
 
 import { WfoMetadataPageLayout } from './WfoMetadataPageLayout';
 
@@ -223,7 +226,7 @@ export const WfoProductsPage = () => {
                     getProductsForExport,
                     (data) => data.products.page,
                     (data) => data.products.pageInfo,
-                    'Products.csv',
+                    getCsvFileNameWithDate('Products'),
                     addToast,
                     tError,
                 )}

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
@@ -26,6 +26,7 @@ import {
     useQueryWithGraphql,
     useQueryWithGraphqlLazy,
     useStoredTableConfig,
+    useToastMessage,
 } from '@/hooks';
 import type { GraphqlQueryVariables, ProductDefinition } from '@/types';
 import { BadgeType, SortOrder } from '@/types';
@@ -50,6 +51,8 @@ const PRODUCT_FIELD_CREATED_AT: keyof ProductDefinition = 'createdAt';
 
 export const WfoProductsPage = () => {
     const t = useTranslations('metadata.products');
+    const tError = useTranslations('errors');
+    const { addToast } = useToastMessage();
     const [tableDefaults, setTableDefaults] =
         useState<StoredTableConfig<ProductDefinition>>();
 
@@ -219,7 +222,10 @@ export const WfoProductsPage = () => {
                 onExportData={csvDownloadHandler(
                     getProductsForExport,
                     (data) => data.products.page,
+                    (data) => data.products.pageInfo,
                     'Products.csv',
+                    addToast,
+                    tError,
                 )}
                 exportDataIsLoading={isFetchingCsv}
             />

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
@@ -6,7 +6,10 @@ import { EuiBadgeGroup } from '@elastic/eui';
 import type { Pagination } from '@elastic/eui/src/components';
 
 import { getQueryVariablesForExport } from '@/utils';
-import { csvDownloadHandler } from '@/utils/csvDownload';
+import {
+    csvDownloadHandler,
+    getCsvFileNameWithDate,
+} from '@/utils/csvDownload';
 
 import {
     DEFAULT_PAGE_SIZE,
@@ -199,7 +202,7 @@ export const WfoResourceTypesPage = () => {
                     getResourceTypesForExport,
                     (data) => data.resourceTypes.page,
                     (data) => data.resourceTypes.pageInfo,
-                    'ResourceTypes.csv',
+                    getCsvFileNameWithDate('ResourceTypes'),
                     addToast,
                     tError,
                 )}

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
@@ -30,6 +30,7 @@ import {
     useQueryWithGraphql,
     useQueryWithGraphqlLazy,
     useStoredTableConfig,
+    useToastMessage,
 } from '../../hooks';
 import type {
     GraphqlQueryVariables,
@@ -49,6 +50,8 @@ export const RESOURCE_TYPE_FIELD_PRODUCT_BLOCKS: keyof ResourceTypeDefinition =
 
 export const WfoResourceTypesPage = () => {
     const t = useTranslations('metadata.resourceTypes');
+    const tError = useTranslations('errors');
+    const { addToast } = useToastMessage();
 
     const [tableDefaults, setTableDefaults] =
         useState<StoredTableConfig<ResourceTypeDefinition>>();
@@ -195,7 +198,10 @@ export const WfoResourceTypesPage = () => {
                 onExportData={csvDownloadHandler(
                     getResourceTypesForExport,
                     (data) => data.resourceTypes.page,
+                    (data) => data.resourceTypes.pageInfo,
                     'ResourceTypes.csv',
+                    addToast,
+                    tError,
                 )}
                 exportDataIsLoading={isFetchingCsv}
             />

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
@@ -202,6 +202,7 @@ export const WfoResourceTypesPage = () => {
                     getResourceTypesForExport,
                     (data) => data.resourceTypes.page,
                     (data) => data.resourceTypes.pageInfo,
+                    Object.keys(tableColumns),
                     getCsvFileNameWithDate('ResourceTypes'),
                     addToast,
                     tError,

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
@@ -212,6 +212,7 @@ export const WfoWorkflowsPage = () => {
                     getWorkflowsForExport,
                     (data) => data.workflows.page,
                     (data) => data.workflows.pageInfo,
+                    Object.keys(tableColumns),
                     getCsvFileNameWithDate('Workflows'),
                     addToast,
                     tError,

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
@@ -5,7 +5,10 @@ import { useTranslations } from 'next-intl';
 import { EuiBadgeGroup } from '@elastic/eui';
 import type { Pagination } from '@elastic/eui/src/components';
 
-import { csvDownloadHandler } from '@/utils/csvDownload';
+import {
+    csvDownloadHandler,
+    getCsvFileNameWithDate,
+} from '@/utils/csvDownload';
 
 import {
     DEFAULT_PAGE_SIZE,
@@ -209,7 +212,7 @@ export const WfoWorkflowsPage = () => {
                     getWorkflowsForExport,
                     (data) => data.workflows.page,
                     (data) => data.workflows.pageInfo,
-                    'Workflows.csv',
+                    getCsvFileNameWithDate('Workflows'),
                     addToast,
                     tError,
                 )}

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
@@ -30,6 +30,7 @@ import {
     useQueryWithGraphql,
     useQueryWithGraphqlLazy,
     useStoredTableConfig,
+    useToastMessage,
 } from '../../hooks';
 import type { GraphqlQueryVariables, WorkflowDefinition } from '../../types';
 import { BadgeType, SortOrder } from '../../types';
@@ -53,6 +54,8 @@ export type WorkflowListItem = Pick<
 
 export const WfoWorkflowsPage = () => {
     const t = useTranslations('metadata.workflows');
+    const tError = useTranslations('errors');
+    const { addToast } = useToastMessage();
 
     const [tableDefaults, setTableDefaults] =
         useState<StoredTableConfig<WorkflowListItem>>();
@@ -205,7 +208,10 @@ export const WfoWorkflowsPage = () => {
                 onExportData={csvDownloadHandler(
                     getWorkflowsForExport,
                     (data) => data.workflows.page,
+                    (data) => data.workflows.pageInfo,
                     'Workflows.csv',
+                    addToast,
+                    tError,
                 )}
                 exportDataIsLoading={isFetchingCsv}
             />

--- a/packages/orchestrator-ui-components/src/utils/csvDownload.ts
+++ b/packages/orchestrator-ui-components/src/utils/csvDownload.ts
@@ -34,6 +34,19 @@ export function initiateCsvFileDownload<T extends object>(
     startCsvDownload(csvFileContent, fileName);
 }
 
+export const getCsvFileNameWithDate = (fileNameWithoutExtension: string) => {
+    const date = new Date();
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate();
+
+    const hour = date.getHours();
+    const minute = date.getMinutes();
+    const second = date.getSeconds();
+
+    return `${fileNameWithoutExtension}_${year}-${month}-${day}-${hour}${minute}${second}.csv`;
+};
+
 export const csvDownloadHandler =
     <T extends object, U extends object>(
         dataFetchFunction: () => Promise<T | undefined>,

--- a/packages/orchestrator-ui-components/src/utils/csvDownload.ts
+++ b/packages/orchestrator-ui-components/src/utils/csvDownload.ts
@@ -27,3 +27,18 @@ export function initiateCsvFileDownload<T extends object>(
     const csvFileContent = toCsvFileContent(data);
     startCsvDownload(csvFileContent, fileName);
 }
+
+export const csvDownloadHandler =
+    <T extends object, U extends object>(
+        dataFetchFunction: () => Promise<T | undefined>,
+        dataMapper: (data: T) => U[],
+        filename: string,
+    ) =>
+    async () => {
+        const data: T | undefined = await dataFetchFunction();
+
+        if (data) {
+            const dataForExport = dataMapper(data);
+            initiateCsvFileDownload(dataForExport, filename);
+        }
+    };

--- a/packages/orchestrator-ui-components/src/utils/csvDownload.ts
+++ b/packages/orchestrator-ui-components/src/utils/csvDownload.ts
@@ -3,6 +3,7 @@ import { TranslationValues } from 'next-intl';
 import { MAXIMUM_ITEMS_FOR_BULK_FETCHING } from '@/configuration/constants';
 import { ToastTypes } from '@/contexts';
 import { GraphQLPageInfo } from '@/types';
+import { sortObjectKeys } from '@/utils/sortObjectKeys';
 
 function toCsvFileContent<T extends object>(data: T[]): string {
     const headers = Object.keys(data[0]).join(';');
@@ -52,6 +53,7 @@ export const csvDownloadHandler =
         dataFetchFunction: () => Promise<T | undefined>,
         dataMapper: (data: T) => U[],
         pageInfoMapper: (data: T) => GraphQLPageInfo,
+        keyOrder: string[],
         filename: string,
         addToastFunction: (
             type: ToastTypes,
@@ -67,7 +69,9 @@ export const csvDownloadHandler =
         const data: T | undefined = await dataFetchFunction();
 
         if (data) {
-            const dataForExport = dataMapper(data);
+            const dataForExport = dataMapper(data).map((d) =>
+                sortObjectKeys(d, keyOrder),
+            );
             const pageInfo = pageInfoMapper(data);
             (pageInfo.totalItems ?? 0) > MAXIMUM_ITEMS_FOR_BULK_FETCHING &&
                 addToastFunction(

--- a/packages/orchestrator-ui-components/src/utils/csvDownload.ts
+++ b/packages/orchestrator-ui-components/src/utils/csvDownload.ts
@@ -1,0 +1,29 @@
+function toCsvFileContent<T extends object>(data: T[]): string {
+    const headers = Object.keys(data[0]).join(';');
+    const rows = data.map((row) =>
+        Object.values(row)
+            .map((value) => (value === null ? '' : `"${value}"`))
+            .join(';')
+            .split('\n')
+            .join(' '),
+    );
+    return [headers, ...rows].join('\n');
+}
+
+function startCsvDownload(csvFileContent: string, fileName: string) {
+    const blob = new Blob([csvFileContent], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName.endsWith('.csv') ? fileName : `${fileName}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+}
+
+export function initiateCsvFileDownload<T extends object>(
+    data: T[],
+    fileName: string,
+) {
+    const csvFileContent = toCsvFileContent(data);
+    startCsvDownload(csvFileContent, fileName);
+}

--- a/packages/orchestrator-ui-components/src/utils/getQueryVariablesForExport.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/getQueryVariablesForExport.spec.ts
@@ -1,0 +1,19 @@
+import { getQueryVariablesForExport } from './getQueryVariablesForExport';
+
+describe('getQueryVariablesForExport', () => {
+    it('returns queryVariables with first and after property set to 1000 and 0', () => {
+        const queryVariables = {
+            first: 10,
+            after: 20,
+            otherField: 'test',
+        };
+
+        const result = getQueryVariablesForExport(queryVariables);
+
+        expect(result).toEqual({
+            first: 1000,
+            after: 0,
+            otherField: 'test',
+        });
+    });
+});

--- a/packages/orchestrator-ui-components/src/utils/getQueryVariablesForExport.ts
+++ b/packages/orchestrator-ui-components/src/utils/getQueryVariablesForExport.ts
@@ -1,5 +1,6 @@
-import { MAXIMUM_ITEMS_FOR_BULK_FETCHING } from '@/configuration/constants';
 import type { GraphqlQueryVariables } from '@/types';
+
+import { MAXIMUM_ITEMS_FOR_BULK_FETCHING } from '../configuration/constants';
 
 export const getQueryVariablesForExport = <T extends object>(
     queryVariables: GraphqlQueryVariables<T>,

--- a/packages/orchestrator-ui-components/src/utils/getQueryVariablesForExport.ts
+++ b/packages/orchestrator-ui-components/src/utils/getQueryVariablesForExport.ts
@@ -1,0 +1,9 @@
+import type { GraphqlQueryVariables } from '@/types';
+
+export const getQueryVariablesForExport = <T extends object>(
+    queryVariables: GraphqlQueryVariables<T>,
+) => ({
+    ...queryVariables,
+    first: 1000,
+    after: 0,
+});

--- a/packages/orchestrator-ui-components/src/utils/getQueryVariablesForExport.ts
+++ b/packages/orchestrator-ui-components/src/utils/getQueryVariablesForExport.ts
@@ -1,9 +1,10 @@
+import { MAXIMUM_ITEMS_FOR_BULK_FETCHING } from '@/configuration/constants';
 import type { GraphqlQueryVariables } from '@/types';
 
 export const getQueryVariablesForExport = <T extends object>(
     queryVariables: GraphqlQueryVariables<T>,
 ) => ({
     ...queryVariables,
-    first: 1000,
+    first: MAXIMUM_ITEMS_FOR_BULK_FETCHING,
     after: 0,
 });

--- a/packages/orchestrator-ui-components/src/utils/index.ts
+++ b/packages/orchestrator-ui-components/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './getTypedFieldFromObject';
 export * from './uuid';
 export * from './strings';
 export * from './getProductNamesFromProcess';
+export * from './getQueryVariablesForExport';

--- a/packages/orchestrator-ui-components/src/utils/sortObjectKeys.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/sortObjectKeys.spec.ts
@@ -1,0 +1,18 @@
+import { sortObjectKeys } from './sortObjectKeys';
+
+describe('sortObjectKeys', () => {
+    it('sorts the keys of an object', () => {
+        const testObject = {
+            a: 1,
+            b: 2,
+            c: 3,
+        };
+        const sortedObject = sortObjectKeys(testObject, ['b', 'a', 'c']);
+
+        // Verifies order of keys
+        expect(Object.keys(sortedObject).join('-')).toEqual('b-a-c');
+
+        // Verifies values
+        expect(sortedObject).toEqual({ a: 1, b: 2, c: 3 });
+    });
+});

--- a/packages/orchestrator-ui-components/src/utils/sortObjectKeys.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/sortObjectKeys.spec.ts
@@ -15,4 +15,20 @@ describe('sortObjectKeys', () => {
         // Verifies values
         expect(sortedObject).toEqual({ a: 1, b: 2, c: 3 });
     });
+
+    it('handles missing keys in the keyOrder array', () => {
+        const testObject = {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+        };
+        const sortedObject = sortObjectKeys(testObject, ['d', 'a']);
+
+        // Verifies order of keys
+        expect(Object.keys(sortedObject).join('-')).toEqual('d-a-b-c');
+
+        // Verifies values
+        expect(sortedObject).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+    });
 });

--- a/packages/orchestrator-ui-components/src/utils/sortObjectKeys.ts
+++ b/packages/orchestrator-ui-components/src/utils/sortObjectKeys.ts
@@ -1,0 +1,20 @@
+import { getTypedFieldFromObject } from './getTypedFieldFromObject';
+
+// Some components in this project need the keys of an object to be in a certain order
+// This function sorts the keys of an object based on an array of strings
+// Keys that do not exist in the object will be ignored
+export const sortObjectKeys = <T extends object>(
+    object: T,
+    keyOrder: string[],
+): T => {
+    const sortedObject: Partial<T> = {};
+
+    keyOrder.forEach((key) => {
+        const keyOfT = getTypedFieldFromObject(key, object);
+        if (keyOfT !== null) {
+            sortedObject[keyOfT] = object[keyOfT];
+        }
+    });
+
+    return sortedObject as T;
+};

--- a/packages/orchestrator-ui-components/src/utils/sortObjectKeys.ts
+++ b/packages/orchestrator-ui-components/src/utils/sortObjectKeys.ts
@@ -1,20 +1,33 @@
-import { getTypedFieldFromObject } from './getTypedFieldFromObject';
-
 // Some components in this project need the keys of an object to be in a certain order
 // This function sorts the keys of an object based on an array of strings
 // Keys that do not exist in the object will be ignored
 export const sortObjectKeys = <T extends object>(
-    object: T,
+    inputObject: T,
     keyOrder: string[],
 ): T => {
-    const sortedObject: Partial<T> = {};
+    const allInputObjectKeys = Object.keys(inputObject) as Array<keyof T>;
+    allInputObjectKeys.sort((left, right) => {
+        const leftIndex = keyOrder.indexOf(left.toString());
+        const rightIndex = keyOrder.indexOf(right.toString());
 
-    keyOrder.forEach((key) => {
-        const keyOfT = getTypedFieldFromObject(key, object);
-        if (keyOfT !== null) {
-            sortedObject[keyOfT] = object[keyOfT];
+        if (leftIndex === -1 && rightIndex === -1) {
+            return 0;
         }
+
+        if (leftIndex === -1) {
+            return 1;
+        }
+
+        if (rightIndex === -1) {
+            return -1;
+        }
+
+        return leftIndex - rightIndex;
     });
 
-    return sortedObject as T;
+    // Using all keys from the input object means the result will contain all keys of T, meaning the type is T
+    return allInputObjectKeys.reduce((acc, key) => {
+        acc[key] = inputObject[key];
+        return acc;
+    }, {} as T);
 };


### PR DESCRIPTION
#544 

- Export functionality to export the data from data list pages (subscription list page etc)
- Respects the set filters, but always fetches the first 1000 records
- Always exports all columns available on the page
- Places the export helper funtions in a util file
- Adds a lazy data fetch hook for graphql data -- this prevents that these 1000 records are being fetched on page load.
- not implementing the onExportData prop of the WfoTableWithFilter results in not rendering the Export button to make the export functionality optional

![image](https://github.com/workfloworchestrator/orchestrator-ui/assets/20791917/08d55a4e-8f96-431d-8e82-ae2d47c99062)
