### PR TITLE
598 Fixes invisible email in step list

### DIFF
--- a/.changeset/sixty-hounds-mix.md
+++ b/.changeset/sixty-hounds-mix.md
@@ -1,5 +1,5 @@
 ---
-"@orchestrator-ui/orchestrator-ui-components": patch
+'@orchestrator-ui/orchestrator-ui-components': patch
 ---
 
 598 Fixes invisible email in step list

--- a/.changeset/sixty-hounds-mix.md
+++ b/.changeset/sixty-hounds-mix.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+598 Fixes invisible email in step list

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStep.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStep.tsx
@@ -59,7 +59,8 @@ export const WfoStep = React.forwardRef(
         const stepContent = step.stateDelta
             ? getStepContent(step.stateDelta, showHiddenKeys)
             : {};
-        const hasStepContent = Object.keys(stepContent).length > 0;
+        const hasStepContent =
+            hasHtmlMail || Object.keys(stepContent).length > 0;
 
         const displayMailConfirmation = (value: EmailState) => {
             if (!value) {
@@ -156,13 +157,13 @@ export const WfoStep = React.forwardRef(
                             )}
                         </EuiFlexGroup>
                     </EuiFlexGroup>
-                    {hasStepContent && isExpanded && (
+                    {hasStepContent && !hasHtmlMail && isExpanded && (
                         <WfoJsonCodeBlock data={stepContent} />
                     )}
                     {isExpanded && hasHtmlMail && (
                         <div css={stepEmailContainerStyle}>
                             {displayMailConfirmation(
-                                step.state.confirmation_mail as EmailState,
+                                step.stateDelta.confirmation_mail as EmailState,
                             )}
                         </div>
                     )}

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -217,7 +217,7 @@ export interface Step {
     status: StepStatus;
     stepId: string; // sic backend
     executed: string;
-    state: StepState;
+    state: StepState | undefined;
     stateDelta: StepState;
 }
 


### PR DESCRIPTION
#598 

- A step contraining html was not considered as step content -- now it does
- Bonus: a json output was shown above the email when hiddenKey was enabled