### PR TITLE
Fixes loading state for all tables. Removes keepPreviousData.

### DIFF
--- a/.changeset/popular-carrots-change.md
+++ b/.changeset/popular-carrots-change.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+Table enhancements: Introduces a loading-placeholder and a no-data-placeholder. Prevents showing previous page results while loading new data.

--- a/apps/wfo-ui-surf/pages/_app.tsx
+++ b/apps/wfo-ui-surf/pages/_app.tsx
@@ -46,7 +46,6 @@ const queryClientConfig: QueryClientConfig = {
         queries: {
             cacheTime: 5 * 1000,
             refetchOnWindowFocus: true,
-            keepPreviousData: true,
         },
     },
 };

--- a/apps/wfo-ui/pages/_app.tsx
+++ b/apps/wfo-ui/pages/_app.tsx
@@ -38,7 +38,6 @@ const queryClientConfig: QueryClientConfig = {
         queries: {
             cacheTime: 5 * 1000,
             refetchOnWindowFocus: true,
-            keepPreviousData: true,
         },
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "@emotion/react": "^11.11.1",
                 "@graphql-typed-document-node/core": "3.2.0",
                 "@orchestrator-ui/orchestrator-ui-components": "*",
+                "@reduxjs/toolkit": "^2.0.1",
                 "graphql": "^16.8.1",
                 "graphql-request": "^6.1.0",
                 "moment": "^2.29.4",
@@ -41,6 +42,7 @@
                 "react-dom": "^18.2.0",
                 "react-no-ssr": "^1.1.0",
                 "react-query": "3.39.3",
+                "react-redux": "^9.1.0",
                 "use-query-params": "2.2.1"
             },
             "devDependencies": {
@@ -65,6 +67,7 @@
                 "@emotion/react": "^11.11.1",
                 "@graphql-typed-document-node/core": "3.2.0",
                 "@orchestrator-ui/orchestrator-ui-components": "*",
+                "@reduxjs/toolkit": "^2.0.1",
                 "graphql": "^16.8.1",
                 "graphql-request": "^6.1.0",
                 "moment": "^2.29.4",
@@ -78,6 +81,7 @@
                 "react-dom": "^18.2.0",
                 "react-no-ssr": "^1.1.0",
                 "react-query": "3.39.3",
+                "react-redux": "^9.1.0",
                 "use-query-params": "2.2.1"
             },
             "devDependencies": {
@@ -231,6 +235,39 @@
                     "optional": true
                 }
             }
+        },
+        "apps/wfo-ui-surf/node_modules/react-redux": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+            "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.3",
+                "use-sync-external-store": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25",
+                "react": "^18.0",
+                "react-native": ">=0.69",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
+        "apps/wfo-ui-surf/node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "optional": true,
+            "peer": true
         },
         "apps/wfo-ui-surf/node_modules/supports-color": {
             "version": "7.2.0",
@@ -395,6 +432,39 @@
                     "optional": true
                 }
             }
+        },
+        "apps/wfo-ui/node_modules/react-redux": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+            "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.3",
+                "use-sync-external-store": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25",
+                "react": "^18.0",
+                "react-native": ">=0.69",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
+        "apps/wfo-ui/node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "optional": true,
+            "peer": true
         },
         "apps/wfo-ui/node_modules/supports-color": {
             "version": "7.2.0",
@@ -5715,6 +5785,42 @@
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
+            }
+        },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
+            "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
+            "dependencies": {
+                "immer": "^10.0.3",
+                "redux": "^5.0.0",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.0.1"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@reduxjs/toolkit/node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+        },
+        "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -17493,6 +17599,15 @@
                 "node": ">=16.x"
             }
         },
+        "node_modules/immer": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+            "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -25578,6 +25693,11 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
         },
+        "node_modules/reselect": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+            "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
+        },
         "node_modules/resolve": {
             "version": "1.22.8",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -30807,7 +30927,8 @@
                 "@elastic/eui": "^92.1.0",
                 "next": "^14.0.4",
                 "react": "^18.2.0",
-                "react-dom": "^18.2.0"
+                "react-dom": "^18.2.0",
+                "react-redux": "^9.1.0"
             }
         },
         "packages/orchestrator-ui-components/node_modules/@next/swc-darwin-arm64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
                 "@emotion/react": "^11.11.1",
                 "@graphql-typed-document-node/core": "3.2.0",
                 "@orchestrator-ui/orchestrator-ui-components": "*",
-                "@reduxjs/toolkit": "^2.0.1",
                 "graphql": "^16.8.1",
                 "graphql-request": "^6.1.0",
                 "moment": "^2.29.4",
@@ -42,7 +41,6 @@
                 "react-dom": "^18.2.0",
                 "react-no-ssr": "^1.1.0",
                 "react-query": "3.39.3",
-                "react-redux": "^9.1.0",
                 "use-query-params": "2.2.1"
             },
             "devDependencies": {
@@ -67,7 +65,6 @@
                 "@emotion/react": "^11.11.1",
                 "@graphql-typed-document-node/core": "3.2.0",
                 "@orchestrator-ui/orchestrator-ui-components": "*",
-                "@reduxjs/toolkit": "^2.0.1",
                 "graphql": "^16.8.1",
                 "graphql-request": "^6.1.0",
                 "moment": "^2.29.4",
@@ -81,7 +78,6 @@
                 "react-dom": "^18.2.0",
                 "react-no-ssr": "^1.1.0",
                 "react-query": "3.39.3",
-                "react-redux": "^9.1.0",
                 "use-query-params": "2.2.1"
             },
             "devDependencies": {
@@ -235,39 +231,6 @@
                     "optional": true
                 }
             }
-        },
-        "apps/wfo-ui-surf/node_modules/react-redux": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
-            "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
-            "dependencies": {
-                "@types/use-sync-external-store": "^0.0.3",
-                "use-sync-external-store": "^1.0.0"
-            },
-            "peerDependencies": {
-                "@types/react": "^18.2.25",
-                "react": "^18.0",
-                "react-native": ">=0.69",
-                "redux": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "react-native": {
-                    "optional": true
-                },
-                "redux": {
-                    "optional": true
-                }
-            }
-        },
-        "apps/wfo-ui-surf/node_modules/redux": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "optional": true,
-            "peer": true
         },
         "apps/wfo-ui-surf/node_modules/supports-color": {
             "version": "7.2.0",
@@ -432,39 +395,6 @@
                     "optional": true
                 }
             }
-        },
-        "apps/wfo-ui/node_modules/react-redux": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
-            "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
-            "dependencies": {
-                "@types/use-sync-external-store": "^0.0.3",
-                "use-sync-external-store": "^1.0.0"
-            },
-            "peerDependencies": {
-                "@types/react": "^18.2.25",
-                "react": "^18.0",
-                "react-native": ">=0.69",
-                "redux": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "react-native": {
-                    "optional": true
-                },
-                "redux": {
-                    "optional": true
-                }
-            }
-        },
-        "apps/wfo-ui/node_modules/redux": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "optional": true,
-            "peer": true
         },
         "apps/wfo-ui/node_modules/supports-color": {
             "version": "7.2.0",
@@ -5785,42 +5715,6 @@
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
-            }
-        },
-        "node_modules/@reduxjs/toolkit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
-            "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
-            "dependencies": {
-                "immer": "^10.0.3",
-                "redux": "^5.0.0",
-                "redux-thunk": "^3.1.0",
-                "reselect": "^5.0.1"
-            },
-            "peerDependencies": {
-                "react": "^16.9.0 || ^17.0.0 || ^18",
-                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "react": {
-                    "optional": true
-                },
-                "react-redux": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@reduxjs/toolkit/node_modules/redux": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
-        },
-        "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-            "peerDependencies": {
-                "redux": "^5.0.0"
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -17599,15 +17493,6 @@
                 "node": ">=16.x"
             }
         },
-        "node_modules/immer": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
-            "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/immer"
-            }
-        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -25693,11 +25578,6 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
         },
-        "node_modules/reselect": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
-            "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
-        },
         "node_modules/resolve": {
             "version": "1.22.8",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -30927,8 +30807,7 @@
                 "@elastic/eui": "^92.1.0",
                 "next": "^14.0.4",
                 "react": "^18.2.0",
-                "react-dom": "^18.2.0",
-                "react-redux": "^9.1.0"
+                "react-dom": "^18.2.0"
             }
         },
         "packages/orchestrator-ui-components/node_modules/@next/swc-darwin-arm64": {

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/WfoSubscriptionsList.tsx
@@ -155,7 +155,7 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
         filterBy: alwaysOnFilters,
         query: queryString || undefined,
     };
-    const { data, isError, isLoading } = useQueryWithGraphql(
+    const { data, isError, isFetching } = useQueryWithGraphql(
         getSubscriptionsListGraphQlQuery<SubscriptionListItem>(),
         graphqlQueryVariables,
         ['subscriptions', 'listPage'],
@@ -205,7 +205,7 @@ export const WfoSubscriptionsList: FC<WfoSubscriptionsListProps> = ({
             defaultHiddenColumns={hiddenColumns}
             dataSorting={dataSorting}
             pagination={pagination}
-            isLoading={isLoading}
+            isLoading={isFetching}
             localStorageKey={SUBSCRIPTIONS_TABLE_LOCAL_STORAGE_KEY}
             detailModalTitle={'Details - Subscription'}
             onUpdatePage={getPageChangeHandler<SubscriptionListItem>(

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoBasicTable/WfoBasicTable.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoBasicTable/WfoBasicTable.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode } from 'react';
 
+import { useTranslations } from 'next-intl';
+
 import { EuiBasicTable, EuiBasicTableColumn, Pagination } from '@elastic/eui';
 import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
 import { SerializedStyles } from '@emotion/react';
@@ -68,6 +70,8 @@ export const WfoBasicTable = <T extends object>({
     const { theme } = useOrchestratorTheme();
     const { basicTableStyle } = getWfoBasicTableStyles(theme);
 
+    const t = useTranslations('common');
+
     const statusColorColumn: WfoTableControlColumnConfig<T> = {
         statusColorField: {
             field: WFO_STATUS_COLOR_FIELD,
@@ -94,6 +98,7 @@ export const WfoBasicTable = <T extends object>({
         <EuiBasicTable
             css={tableStyling}
             items={data}
+            noItemsMessage={isLoading ? t('loading') : t('noItemsFound')}
             columns={mapWfoTableColumnsToEuiColumns(
                 allTableColumns,
                 hiddenColumns,

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -19,9 +19,11 @@
         "deselect": "Deselect",
         "close": "Close",
         "editColumns": "Edit columns",
+        "loading": "Loading",
         "newSubscription": "New subscription",
         "newTask": "New task",
         "noFailedTasks": "No failed tasks!",
+        "noItemsFound": "No items found",
         "search": "Search",
         "errorMessage": "An error occurred",
         "export": "Export"

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -19,9 +19,11 @@
         "deselect": "Deselecteer",
         "close": "Sluiten",
         "editColumns": "Wijzig kolommen",
+        "loading": "Laden",
         "newSubscription": "Nieuwe subscription",
         "newTask": "Nieuwe task",
         "noFailedTasks": "Geen gefaalde taken!",
+        "noItemsFound": "Geen items gevonden",
         "search": "Zoeken",
         "errorMessage": "Er is een fout opgetreden",
         "export": "Exporteren"

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
@@ -201,7 +201,7 @@ export const WfoProductBlocksPage = () => {
             sortBy: sortBy,
             query: queryString || undefined,
         };
-    const { data, isLoading, isError } = useQueryWithGraphql(
+    const { data, isFetching, isError } = useQueryWithGraphql(
         GET_PRODUCTS_BLOCKS_GRAPHQL_QUERY,
         graphqlQueryVariables,
         ['productBlocks', 'listPage'],
@@ -249,7 +249,7 @@ export const WfoProductBlocksPage = () => {
                     setDataDisplayParam,
                 )}
                 pagination={pagination}
-                isLoading={isLoading}
+                isLoading={isFetching}
                 hasError={isError}
                 queryString={queryString}
                 localStorageKey={

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
@@ -170,7 +170,7 @@ export const WfoProductsPage = () => {
         sortBy: sortBy,
         query: queryString || undefined,
     };
-    const { data, isLoading, isError } = useQueryWithGraphql(
+    const { data, isFetching, isError } = useQueryWithGraphql(
         getProductsQuery(),
         graphqlQueryVariables,
         ['products', 'listPage'],
@@ -218,7 +218,7 @@ export const WfoProductsPage = () => {
                     setDataDisplayParam,
                 )}
                 pagination={pagination}
-                isLoading={isLoading}
+                isLoading={isFetching}
                 hasError={isError}
                 queryString={queryString}
                 localStorageKey={METADATA_PRODUCT_TABLE_LOCAL_STORAGE_KEY}

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
@@ -144,7 +144,7 @@ export const WfoResourceTypesPage = () => {
             sortBy: sortBy,
             query: queryString || undefined,
         };
-    const { data, isLoading, isError } = useQueryWithGraphql(
+    const { data, isFetching, isError } = useQueryWithGraphql(
         GET_RESOURCE_TYPES_GRAPHQL_QUERY,
         graphqlQueryVariables,
         ['resourceTypes', 'listPage'],
@@ -192,7 +192,7 @@ export const WfoResourceTypesPage = () => {
                     setDataDisplayParam,
                 )}
                 pagination={pagination}
-                isLoading={isLoading}
+                isLoading={isFetching}
                 hasError={isError}
                 queryString={queryString}
                 localStorageKey={

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
@@ -156,7 +156,7 @@ export const WfoWorkflowsPage = () => {
         sortBy: graphQlWorkflowListMapper(sortBy),
         query: queryString || undefined,
     };
-    const { data, isLoading, isError } = useQueryWithGraphql(
+    const { data, isFetching, isError } = useQueryWithGraphql(
         GET_WORKFLOWS_GRAPHQL_QUERY,
         graphqlQueryVariables,
         ['workflows', 'listPage'],
@@ -204,7 +204,7 @@ export const WfoWorkflowsPage = () => {
                     setDataDisplayParam,
                 )}
                 pagination={pagination}
-                isLoading={isLoading}
+                isLoading={isFetching}
                 hasError={isError}
                 queryString={queryString}
                 localStorageKey={METADATA_WORKFLOWS_TABLE_LOCAL_STORAGE_KEY}


### PR DESCRIPTION
Removal of keepPreviousData: when this was enabled the second page would still show data from page 1 until the data is fetched. This might confuse the user.

Switched from isLoading to isFetching: isFetching is, in contrast with isLoading, `true` when data gets refetched from the backend.

Added messages for the `no-data` state of the table: we distinguish now between "no data, because data is loading" and "no results found"

