### PR TITLE
use PAT instead of GITHUB_TOKEN to trigger tag example-orchestrator-ui action

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -36,5 +36,5 @@ jobs:
               with:
                   publish: npm run packages:publish
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.TAG_EXAMPLE_ORCHESTRATOR_UI_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
There are two depended actions, one that builds the package and pushes it to NPM and creates a tag, and one that reacts on that tag to create a tag in the example-orchestrator-ui to trigger a build of a new container in that repository with the just published new NPM package. But GitHub does not allow to trigger an action from another action, probably to prevent possible trigger loops. A way to circumvent this restriction is to use a Personal Access Token to create the first tag. The easiest solution is to use the same PAT that is also used to create the second tag.