### PR TITLE
719: Remove turbo eslint rules so downstream pacakges dont fail them

### DIFF
--- a/.changeset/long-carrots-kneel.md
+++ b/.changeset/long-carrots-kneel.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/eslint-config-custom": minor
+---
+
+Remove turborepo linting rule

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -3,7 +3,6 @@ module.exports = {
         'plugin:@typescript-eslint/recommended',
         'next',
         'next/core-web-vitals',
-        'turbo',
         'prettier',
     ],
     rules: {

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -11,7 +11,6 @@
         "eslint": "^8.56.0",
         "eslint-config-next": "^14.0.4",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-config-turbo": "^1.11.1",
         "eslint-plugin-react": "^7.28.0"
     },
     "publishConfig": {


### PR DESCRIPTION
Remove turbo as standard extend option for eslint configurations so builds usingt this package wont fail if they dont use turbo