### PR TITLE
651: Fix incorrect port select options

### DIFF
--- a/.changeset/fresh-frogs-matter.md
+++ b/.changeset/fresh-frogs-matter.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+651: Fix incorrect port select options

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/utils.spec.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/utils.spec.ts
@@ -99,7 +99,7 @@ describe('formField utils', () => {
             expect(result).toEqual('NOTTAGGED');
         });
 
-        it('returns undefined if the last portMode if there are more than one productBlockInstanceValue with portmode', () => {
+        it('returns the first portMode if there are more than one productBlockInstanceValue with portmode', () => {
             const result = getPortMode([
                 getProductBlockInstance({
                     productBlockInstanceValues: [
@@ -118,7 +118,7 @@ describe('formField utils', () => {
                     ],
                 }),
             ]);
-            expect(result).toEqual('SECOND');
+            expect(result).toEqual('FIRST');
         });
 
         it('returns undefined if the productBlockInstances dont contain a portMode field', () => {

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/utils.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/utils.ts
@@ -7,22 +7,20 @@ import { PortMode, ProductTag } from './surf/types';
 export const getPortMode = (
     productBlockInstances: ProductBlockInstance[],
 ): PortMode | undefined => {
-    const portMode = productBlockInstances?.reduce(
+    return productBlockInstances?.reduce(
         (portMode: PortMode | undefined, productBlockInstance) => {
             const portModeField =
                 productBlockInstance.productBlockInstanceValues.find(
                     (productBlockInstanceValue) =>
                         productBlockInstanceValue.field === 'portMode',
                 );
-            if (portModeField) {
+            if (!portMode && portModeField) {
                 return portModeField.value as PortMode;
             }
             return portMode;
         },
         undefined,
     );
-
-    return portMode;
 };
 
 export const isEmpty = (obj: unknown) => {

--- a/packages/orchestrator-ui-components/src/hooks/surf/useGetSubscriptionDropdownOptions.ts
+++ b/packages/orchestrator-ui-components/src/hooks/surf/useGetSubscriptionDropdownOptions.ts
@@ -6,7 +6,7 @@ import { useQueryWithGraphql } from '../useQueryWithGraphql';
 
 export const useGetSubscriptionDropdownOptions = (
     tags: string[] = [],
-    statuses: string[] = [],
+    statuses: string[] = ['active'],
 ) => {
     // The way the graphql filterBy clause on the backend handled multiple AND values is by joining them with -
     const tagValue = tags.join('-');


### PR DESCRIPTION
- aggsp's have a portMode of `tagged` but it has a linkmember port which has a portMode `link_member` which is taken last in the reduce and becomes the value. I added a check if the portMode isn't set yet in the reduce.
- default status filter needs to be `active` for `useGetSubscriptionDropdownOptions`.

Closes: #651 