### PR TITLE
use GitHub app generated token for repository access

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -11,6 +11,14 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         steps:
+            - name: Create GitHub app token
+              uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ vars.RW_REPOSITORY_CONTENT_APP_ID }}
+                  private-key: ${{ secrets.RW_REPOSITORY_CONTENT_PRIVATE_KEY }}
+                  owner: ${{ github.repository_owner }}
+                  repositories: "orchestrator-ui-library"
             - uses: actions/checkout@v3
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v3
@@ -36,5 +44,5 @@ jobs:
               with:
                   publish: npm run packages:publish
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/tag-example-ui.yml
+++ b/.github/workflows/tag-example-ui.yml
@@ -8,10 +8,9 @@ on:
     tags:
       - "@orchestrator-ui/orchestrator-ui-components@[0-9]+.[0-9]+.[0-9]+"
 
-# The main branch of the following repository (owner/repo) will be tagged
+# The main branch of the following repository will be tagged
 # with the version part (e.g. 0.3.1) of the tag trigger above.
 env:
-  OWNER: "workfloworchestrator"
   REPO: "example-orchestrator-ui"
 
 jobs:
@@ -21,6 +20,14 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Create GitHub app token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RW_REPOSITORY_CONTENT_APP_ID }}
+          private-key: ${{ secrets.RW_REPOSITORY_CONTENT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ process.env.REPO }}
       - name: Get latest commit SHA
         id: sha
         uses: actions/github-script@v7
@@ -28,7 +35,7 @@ jobs:
           result-encoding: string
           script: |
             const commit = await github.rest.repos.getCommit({
-              owner: process.env.OWNER,
+              owner: github.repository_owner,
               repo: process.env.REPO,
               ref: 'heads/main',
             })
@@ -44,10 +51,10 @@ jobs:
           REF: ${{ format('refs/tags/{0}', env.REF) }}
           SHA: ${{ steps.sha.outputs.result }}
         with:
-          github-token: ${{ secrets.TAG_EXAMPLE_ORCHESTRATOR_UI_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.git.createRef({
-              owner: process.env.OWNER,
+              owner: github.repository_owner,
               repo: process.env.REPO,
               ref: process.env.REF,
               sha: process.env.SHA,


### PR DESCRIPTION
Use a GitHub app on the workflow orchestrator organisation with Content and Metadata access to generate tokens that have access to the orchestrator-ui-library and example-orchestrator-ui repositories. This way there is no need to use personal access tokens, and the creation of a tag can trigger another workflow in the same repository.