### PR TITLE
681 Create a connected and an unconnect SelectField

### DIFF
--- a/.changeset/old-fishes-fold.md
+++ b/.changeset/old-fishes-fold.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": minor
+---
+
+Fixes a SelectField bug

--- a/packages/orchestrator-ui-components/src/components/WfoForms/AutoFieldLoader.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/AutoFieldLoader.tsx
@@ -4,6 +4,7 @@ import { AutoField } from 'uniforms-unstyled';
 import {
     AcceptField,
     BoolField,
+    ConnectedSelectField,
     ContactPersonNameField,
     CustomerField,
     DateField,
@@ -20,7 +21,6 @@ import {
     OptGroupField,
     ProductField,
     RadioField,
-    SelectField,
     SubscriptionField,
     SubscriptionSummaryField,
     SummaryField,
@@ -91,7 +91,9 @@ export function autoFieldFunction(
     }
 
     if (allowedValues && format !== 'accept') {
-        return checkboxes && fieldType !== Array ? RadioField : SelectField;
+        return checkboxes && fieldType !== Array
+            ? RadioField
+            : ConnectedSelectField;
     } else {
         switch (fieldType) {
             case Array:

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ConnectedSelectField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ConnectedSelectField.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { connectField } from 'uniforms';
+
+import type { SelectFieldProps } from './SelectField';
+import { SelectField } from './SelectField';
+
+const ConnectedSelect = (props: SelectFieldProps) => {
+    return <SelectField {...props} />;
+};
+
+export const ConnectedSelectField = connectField(ConnectedSelect, {
+    kind: 'leaf',
+});

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ConnectedSelectField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ConnectedSelectField.tsx
@@ -3,10 +3,15 @@ import React from 'react';
 import { connectField } from 'uniforms';
 
 import type { SelectFieldProps } from './SelectField';
-import { SelectField } from './SelectField';
+import { UnconnectedSelectField } from './SelectField';
 
+/*
+ The selectField has a connected and unconnected version. When a SelectField is called from another field that
+ is connected it can cause errors as described here: https://github.com/workfloworchestrator/orchestrator-ui-library/issues/681
+ When called directly it will still need the props that the connectField function provides so it has a connected version as well.
+*/
 const ConnectedSelect = (props: SelectFieldProps) => {
-    return <SelectField {...props} />;
+    return <UnconnectedSelectField {...props} />;
 };
 
 export const ConnectedSelectField = connectField(ConnectedSelect, {

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/CustomerField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/CustomerField.tsx
@@ -19,7 +19,7 @@ import { connectField } from 'uniforms';
 
 import { useGetCustomersQuery } from '@/rtk/endpoints';
 
-import { SelectField, SelectFieldProps } from './SelectField';
+import { SelectFieldProps, UnconnectedSelectField } from './SelectField';
 
 export type CustomerFieldProps = Omit<
     SelectFieldProps,
@@ -40,7 +40,7 @@ function Customer({ ...props }: CustomerFieldProps) {
     }
 
     return (
-        <SelectField
+        <UnconnectedSelectField
             {...props}
             allowedValues={Array.from(uuidCustomerNameMap.keys())}
             transform={(uuid: string) => uuidCustomerNameMap.get(uuid) || uuid}

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ImsNodeIdField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ImsNodeIdField.tsx
@@ -19,7 +19,7 @@ import { useTranslations } from 'next-intl';
 import { connectField, filterDOMProps } from 'uniforms';
 
 import { useAxiosApiClient } from '../useAxiosApiClient';
-import { SelectField, SelectFieldProps } from './SelectField';
+import { SelectFieldProps, UnconnectedSelectField } from './SelectField';
 import { ImsNode } from './surf/types';
 
 export type ImsNodeIdFieldProps = {
@@ -91,7 +91,7 @@ function ImsNodeId({
         }, {}) ?? {};
 
     return (
-        <SelectField
+        <UnconnectedSelectField
             name=""
             {...props}
             allowedValues={Object.keys(imsNodeIdLabelLookup)}

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListSelectField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListSelectField.tsx
@@ -25,7 +25,7 @@ import { joinName, useField, useForm } from 'uniforms';
 import { ListField, ListFieldProps } from './ListField';
 import { ListItemField } from './ListItemField';
 // Avoid circular deps
-import { SelectField } from './SelectField';
+import { UnconnectedSelectField } from './SelectField';
 import { FieldProps } from './types';
 
 export type ListSelectFieldProps = FieldProps<
@@ -71,7 +71,7 @@ export function ListSelectField({
         return (
             <ListField name={name}>
                 <ListItemField name="$">
-                    <SelectField
+                    <UnconnectedSelectField
                         name=""
                         transform={transform}
                         allowedValues={allowedValues}
@@ -83,7 +83,7 @@ export function ListSelectField({
         );
     } else {
         return (
-            <SelectField
+            <UnconnectedSelectField
                 name=""
                 transform={transform}
                 allowedValues={allowedValues}

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/LocationCodeField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/LocationCodeField.tsx
@@ -18,7 +18,7 @@ import { useTranslations } from 'next-intl';
 import { connectField, filterDOMProps } from 'uniforms';
 
 import { useAxiosApiClient } from '../useAxiosApiClient';
-import { SelectField, SelectFieldProps } from './SelectField';
+import { SelectFieldProps, UnconnectedSelectField } from './SelectField';
 
 export type LocationCodeFieldProps = { locationCodes?: string[] } & Omit<
     SelectFieldProps,
@@ -55,7 +55,7 @@ function LocationCode({ locationCodes, ...props }: LocationCodeFieldProps) {
     }, [axiosApiClient]);
 
     return (
-        <SelectField
+        <UnconnectedSelectField
             {...props}
             allowedValues={codes}
             placeholder={t('widgets.locationCode.placeholder')}

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ProductField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ProductField.tsx
@@ -21,7 +21,7 @@ import { connectField, filterDOMProps } from 'uniforms';
 
 import { ProductDefinition } from '../../../types';
 import { useAxiosApiClient } from '../useAxiosApiClient';
-import { SelectField, SelectFieldProps } from './SelectField';
+import { SelectFieldProps, UnconnectedSelectField } from './SelectField';
 
 export type ProductFieldProps = { productIds?: string[] } & Omit<
     SelectFieldProps,
@@ -65,7 +65,7 @@ function Product({ name, productIds, ...props }: ProductFieldProps) {
         }, {}) ?? {};
 
     return (
-        <SelectField
+        <UnconnectedSelectField
             name={name}
             {...props}
             allowedValues={Object.keys(productLabelLookup)}

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/SelectField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/SelectField.tsx
@@ -33,7 +33,10 @@ export type SelectFieldProps = FieldProps<
     { allowedValues?: string[]; transform?(value: string): string }
 >;
 
-export function SelectField({
+/*
+
+*/
+export function UnconnectedSelectField({
     allowedValues = [],
     disabled,
     fieldType,

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/index.ts
@@ -29,3 +29,4 @@ export * from './SubscriptionField';
 export * from './IpNetworkField';
 export * from './SummaryField';
 export * from './CustomerField';
+export * from './ConnectedSelectField';


### PR DESCRIPTION
 The selectField has a connected and unconnected version. When a SelectField is called from another field that
 is connected it can cause errors as described here: https://github.com/workfloworchestrator/orchestrator-ui-library/issues/681.  When called directly it will still need the props that the connectField function provides so it has a connected version as well.