### PR TITLE
Moves @typescript-eslint/eslint-plugin back to dependencies

### DIFF
--- a/.changeset/four-pianos-destroy.md
+++ b/.changeset/four-pianos-destroy.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/eslint-config-custom": patch
+---
+
+Exposing @typescript-eslint/eslint-plugin as dependency instead of devDependency

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -7,6 +7,7 @@
         "dev": "npm run build -- --watch"
     },
     "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^7.0.1",
         "eslint": "^8.56.0",
         "eslint-config-next": "^14.0.4",
         "eslint-config-prettier": "^9.1.0",
@@ -14,8 +15,5 @@
     },
     "publishConfig": {
         "access": "public"
-    },
-    "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^7.0.1"
     }
 }


### PR DESCRIPTION
Consuming projects will not receive the rules from @typescript-eslint/eslint-plugin when it is placed in devDependencies