### PR TITLE
812 Adds Product type specifically for REST call for fetching Products

### DIFF
--- a/.changeset/fair-cougars-grab.md
+++ b/.changeset/fair-cougars-grab.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+812 Fixed object mapping from products rest call

--- a/packages/orchestrator-ui-components/src/api/index.ts
+++ b/packages/orchestrator-ui-components/src/api/index.ts
@@ -14,6 +14,7 @@
  */
 import { AxiosInstance } from 'axios';
 
+import { LegacyProduct } from '@/api/types';
 import {
     ImsPort,
     IpBlock,
@@ -142,8 +143,8 @@ export class ApiClient extends BaseApiClient {
         );
     };
 
-    products = (): Promise<ProductDefinition[]> => {
-        return this.fetchJson<ProductDefinition[]>(PRODUCTS_ENDPOINT);
+    products = (): Promise<LegacyProduct[]> => {
+        return this.fetchJson<LegacyProduct[]>(PRODUCTS_ENDPOINT);
     };
     productById = (productId: string): Promise<ProductDefinition> => {
         return this.fetchJson(`${PRODUCTS_ENDPOINT}${productId}`);

--- a/packages/orchestrator-ui-components/src/api/types.ts
+++ b/packages/orchestrator-ui-components/src/api/types.ts
@@ -1,0 +1,53 @@
+// These types are specifically for the axios calls
+// When replacing the REST calls with GraphQL, these types should be removed
+
+export type LegacyFixedInput = {
+    name: string;
+    value: string;
+    created_at: number;
+    fixed_input_id: string;
+    product_id: string;
+};
+
+export type LegacyWorkflow = {
+    name: string;
+    description: string;
+    target: string;
+    created_at: number;
+    workflow_id: string;
+};
+
+export type LegacyResourceType = {
+    resource_type_id: string;
+    resource_type: string;
+    description: string;
+};
+
+export type LegacyProductBlock = {
+    product_block_id: string;
+    name: string;
+    tag: string;
+    description: string;
+    status: string;
+    created_at: number;
+    end_date: number;
+    resource_types: LegacyResourceType[];
+    parent_ids: string[];
+};
+
+export type LegacyProduct = {
+    name: string;
+    tag: string;
+    description: string;
+    product_id: string;
+    created_at: number;
+    product_type: string;
+    end_date: number;
+    status: string;
+    fixed_inputs: LegacyFixedInput[];
+    workflows: LegacyWorkflow[];
+    product_blocks: LegacyProductBlock[];
+    create_subscription_workflow_key: string;
+    modify_subscription_workflow_key: string;
+    terminate_subscription_workflow_key: string;
+};

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ProductField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ProductField.tsx
@@ -19,7 +19,7 @@ import get from 'lodash/get';
 import { useTranslations } from 'next-intl';
 import { connectField, filterDOMProps } from 'uniforms';
 
-import { ProductDefinition } from '@/types';
+import type { LegacyProduct } from '@/api/types';
 
 import { useAxiosApiClient } from '../useAxiosApiClient';
 import { SelectFieldProps, UnconnectedSelectField } from './SelectField';
@@ -45,15 +45,15 @@ function Product({ name, productIds, ...props }: ProductFieldProps) {
 
     const productById = (
         id: string,
-        products: ProductDefinition[],
-    ): ProductDefinition => {
-        return products.find((prod) => prod.productId === id)!;
+        products: LegacyProduct[],
+    ): LegacyProduct => {
+        return products.find((prod) => prod.product_id === id)!;
     };
 
-    if (isLoading || error) return null;
+    if (isLoading || error || !data) return null;
 
     const products = productIds
-        ? data?.map((id) => productById(id.productId, data))
+        ? productIds?.map((id) => productById(id, data))
         : data;
 
     const productLabelLookup =
@@ -61,7 +61,7 @@ function Product({ name, productIds, ...props }: ProductFieldProps) {
             mapping,
             product,
         ) {
-            mapping[product.productId] = product.name;
+            mapping[product.product_id] = product.name;
             return mapping;
         }, {}) ?? {};
 


### PR DESCRIPTION
#812 

Note:
Had to introduce a type especially for the rest call for products. Compared to the GraphQL calls, the REST call returns objects with properties in snake_case. Since this type is very specific I prefixed it with `Legacy` and placed it next to the axios client in the code.