### PR TITLE
332 Hides the metadata section when no data is available

### DIFF
--- a/.changeset/serious-cooks-leave.md
+++ b/.changeset/serious-cooks-leave.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+332 Subscription detail page: hides metadata section when there is no data available

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneral.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneral.tsx
@@ -126,6 +126,8 @@ export const WfoSubscriptionGeneral = ({
         ];
     };
 
+    const hasMetadata = Object.entries(subscriptionDetail.metadata).length > 0;
+
     return (
         <EuiFlexGrid direction={'row'}>
             <>
@@ -135,12 +137,14 @@ export const WfoSubscriptionGeneral = ({
                         keyValues={getSubscriptionDetailBlockData()}
                     />
                 </EuiFlexItem>
-                <EuiFlexItem>
-                    <SubscriptionKeyValueBlock
-                        title={t('metadata')}
-                        keyValues={getMetadataBlockData()}
-                    />
-                </EuiFlexItem>
+                {hasMetadata && (
+                    <EuiFlexItem>
+                        <SubscriptionKeyValueBlock
+                            title={t('metadata')}
+                            keyValues={getMetadataBlockData()}
+                        />
+                    </EuiFlexItem>
+                )}
                 <EuiFlexItem>
                     <SubscriptionKeyValueBlock
                         title={t('blockTitleFixedInputs')}


### PR DESCRIPTION
#332

Metadata is not always available, therefore hiding the Metadata section on the SubscriptionDetail>General page when there is no data