### PR TITLE
596 forkable pages

### DIFF
--- a/packages/orchestrator-ui-components/src/components/index.ts
+++ b/packages/orchestrator-ui-components/src/components/index.ts
@@ -26,3 +26,4 @@ export * from './WfoErrorBoundary';
 export * from './WfoWorkflowSteps';
 export * from './WfoNoResults';
 export * from './WfoStartButton';
+export * from './WfoSubscriptionsList';

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -121,6 +121,7 @@
         }
     },
     "metadata": {
+        "title": "Metadata",
         "tabs": {
             "products": "Products",
             "productBlocks": "Product blocks",

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoMetadataPageLayout.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoMetadataPageLayout.tsx
@@ -17,7 +17,7 @@ export interface MetaDataTab {
     path: string;
 }
 
-const metaDataTabs: MetaDataTab[] = [
+export const metaDataTabs: MetaDataTab[] = [
     {
         id: 1,
         translationKey: 'products',
@@ -45,14 +45,14 @@ export const WfoMetadataPageLayout = ({
     tabs = metaDataTabs,
 }: MetadataLayoutProps) => {
     const router = useRouter();
-    const t = useTranslations('metadata.tabs');
+    const t = useTranslations('metadata');
     const currentPath = router.pathname;
 
     return (
         <>
             <EuiSpacer />
 
-            <EuiPageHeader pageTitle="Metadata" />
+            <EuiPageHeader pageTitle={t('title')} />
             <EuiSpacer size="m" />
             <EuiTabs>
                 {tabs.map(({ id, translationKey: name, path }) => (
@@ -61,7 +61,7 @@ export const WfoMetadataPageLayout = ({
                         isSelected={path === currentPath}
                         onClick={() => router.push(path)}
                     >
-                        {t(name)}
+                        {t(`tabs.${name}`)}
                     </EuiTab>
                 ))}
             </EuiTabs>

--- a/packages/orchestrator-ui-components/src/pages/metadata/index.ts
+++ b/packages/orchestrator-ui-components/src/pages/metadata/index.ts
@@ -2,3 +2,5 @@ export * from './WfoProductBlocksPage';
 export * from './WfoResourceTypesPage';
 export * from './WfoProductsPage';
 export * from './WfoWorkflowsPage';
+export * from './WfoMetadataPageLayout';
+export * from './workflowListObjectMapper';

--- a/packages/orchestrator-ui-components/src/pages/subscriptions/WfoSubscriptionDetailPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/subscriptions/WfoSubscriptionDetailPage.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { useRouter } from 'next/router';
 
-import { WfoSubscription } from '../../components';
-import { TreeProvider } from '../../contexts';
+import { WfoSubscription } from '@/components';
+import { TreeProvider } from '@/contexts';
 
 export const WfoSubscriptionDetailPage = () => {
     const router = useRouter();

--- a/packages/orchestrator-ui-components/src/pages/subscriptions/WfoSubscriptionsListPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/subscriptions/WfoSubscriptionsListPage.tsx
@@ -11,12 +11,12 @@ import {
 } from '@/components';
 import { WfoFilterTabs } from '@/components';
 import { StoredTableConfig } from '@/components';
+import type { SubscriptionListItem } from '@/components';
 import {
     WfoSubscriptionListTab,
     WfoSubscriptionsList,
     subscriptionListTabs,
 } from '@/components/WfoSubscriptionsList';
-import { SubscriptionListItem } from '@/components/WfoSubscriptionsList';
 import { useDataDisplayParams, useStoredTableConfig } from '@/hooks';
 import { SortOrder } from '@/types';
 

--- a/packages/orchestrator-ui-components/src/pages/workflows/index.ts
+++ b/packages/orchestrator-ui-components/src/pages/workflows/index.ts
@@ -1,1 +1,3 @@
 export * from './WfoWorkflowsListPage';
+export * from './tabConfig';
+export * from './getWorkflowsListTabTypeFromString';


### PR DESCRIPTION
Ticket: https://github.com/workfloworchestrator/orchestrator-ui-library/issues/596

Makes components exportable that are needed to be able to fork all toplevel pages in the app.

See this PR in the example app for a version were all pages are forked: https://github.com/workfloworchestrator/example-orchestrator-ui/pull/17