### PR TITLE
905: Improve sideBar menu functionality

### DIFF
--- a/.changeset/odd-lobsters-eat.md
+++ b/.changeset/odd-lobsters-eat.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": minor
+---
+
+Adds submenu styling

--- a/.changeset/odd-lobsters-eat.md
+++ b/.changeset/odd-lobsters-eat.md
@@ -1,5 +1,0 @@
----
-"@orchestrator-ui/orchestrator-ui-components": minor
----
-
-Adds submenu styling

--- a/.changeset/silver-ears-jump.md
+++ b/.changeset/silver-ears-jump.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": minor
+---
+
+Improves sideBar navigation

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoMenuLink.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoMenuLink.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react';
+
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+
+import { useWithOrchestratorTheme } from '@/hooks';
+
+import { getMenuItemStyles } from './styles';
+
+type WfoMenuItemLinkProps = {
+    path: string;
+    translationString: string;
+    isSelected: boolean;
+    isSubItem?: boolean;
+};
+
+export const WfoMenuItemLink: FC<WfoMenuItemLinkProps> = ({
+    path,
+    translationString,
+    isSelected,
+    isSubItem,
+}) => {
+    const {
+        menuItemStyle,
+        selectedMenuItem,
+        selectedSubMenuItem,
+        subMenuItemStyle,
+    } = useWithOrchestratorTheme(getMenuItemStyles);
+
+    const getMenuItemStyle = () => {
+        if (isSubItem) {
+            return isSelected ? selectedSubMenuItem : subMenuItemStyle;
+        } else {
+            return isSelected ? selectedMenuItem : menuItemStyle;
+        }
+    };
+
+    const t = useTranslations('main');
+    return (
+        <Link css={getMenuItemStyle()} href={path}>
+            {t(translationString)}
+        </Link>
+    );
+};

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoMenuLink.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoMenuLink.tsx
@@ -36,9 +36,15 @@ export const WfoMenuItemLink: FC<WfoMenuItemLinkProps> = ({
     };
 
     const t = useTranslations('main');
+
+    // This is a workaround to use the translation string as the link text if it's not found in the translation file.
+    const linkText =
+        t(translationString) === `main.${translationString}`
+            ? translationString
+            : t(translationString);
     return (
         <Link css={getMenuItemStyle()} href={path}>
-            {t(translationString)}
+            {linkText}
         </Link>
     );
 };

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
@@ -83,6 +83,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             name: t('subscriptions'),
             id: '4',
             isSelected: router.pathname === PATH_SUBSCRIPTIONS,
+            href: PATH_SUBSCRIPTIONS,
             renderItem: (props) => (
                 <Link className={props.className} href={PATH_SUBSCRIPTIONS}>
                     {t('subscriptions')}
@@ -92,6 +93,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
         {
             name: t('metadata'),
             id: '5',
+            href: PATH_METADATA,
             renderItem: (props) => (
                 <Link className={props.className} href={PATH_METADATA}>
                     {t('metadata')}
@@ -102,6 +104,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     name: t('metadataProducts'),
                     id: '5.1',
                     isSelected: router.pathname === PATH_METADATA_PRODUCTS,
+                    href: PATH_METADATA_PRODUCTS,
                     renderItem: (props) => (
                         <Link
                             className={props.className}
@@ -116,6 +119,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     id: '5.2',
                     isSelected:
                         router.pathname === PATH_METADATA_PRODUCT_BLOCKS,
+                    href: PATH_METADATA_PRODUCT_BLOCKS,
                     renderItem: (props) => (
                         <Link
                             className={props.className}
@@ -128,6 +132,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                 {
                     name: t('metadataResourceTypes'),
                     id: '5.3',
+                    href: PATH_METADATA_RESOURCE_TYPES,
                     isSelected:
                         router.pathname === PATH_METADATA_RESOURCE_TYPES,
                     renderItem: (props) => (
@@ -143,6 +148,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     name: t('metadataWorkflows'),
                     id: '5.4',
                     isSelected: router.pathname === PATH_METADATA_WORKFLOWS,
+                    href: PATH_METADATA_WORKFLOWS,
                     renderItem: (props) => (
                         <Link
                             className={props.className}
@@ -156,6 +162,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     name: t('metadataTasks'),
                     id: '5.5',
                     isSelected: router.pathname === PATH_METADATA_TASKS,
+                    href: PATH_METADATA_TASKS,
                     renderItem: (props) => (
                         <Link
                             className={props.className}
@@ -171,6 +178,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             name: t('tasks'),
             isSelected: router.pathname === PATH_TASKS,
             id: '6',
+            href: PATH_TASKS,
             renderItem: (props) => (
                 <Link className={props.className} href={PATH_TASKS}>
                     {t('tasks')}
@@ -181,6 +189,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             name: t('settings'),
             isSelected: router.pathname === PATH_SETTINGS,
             id: '7',
+            href: PATH_SETTINGS,
             renderItem: (props) => (
                 <Link className={props.className} href={PATH_SETTINGS}>
                     {t('settings')}

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
@@ -4,13 +4,13 @@ import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import { EuiButtonEmpty, EuiSideNav, EuiSpacer } from '@elastic/eui';
+import { EuiSideNav, EuiSpacer } from '@elastic/eui';
 import { EuiSideNavItemType } from '@elastic/eui/src/components/side_nav/side_nav_types';
 
 import { WfoIsAllowedToRender } from '@/components';
 import { WfoStartWorkflowButtonComboBox } from '@/components/WfoStartButton/WfoStartWorkflowComboBox';
 import { PolicyResource } from '@/configuration/policy-resources';
-import { usePolicy, useWithOrchestratorTheme } from '@/hooks';
+import { usePolicy } from '@/hooks';
 
 import {
     PATH_METADATA,
@@ -26,7 +26,6 @@ import {
     PATH_WORKFLOWS,
 } from '../paths';
 import { WfoCopyright } from './WfoCopyright';
-import { getMenuItemStyles } from './styles';
 
 export const renderEmptyElementWhenNotAllowedByPolicy = (isAllowed: boolean) =>
     isAllowed ? undefined : () => <></>;
@@ -55,7 +54,8 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
         setIsSideNavOpenOnMobile((openState) => !openState);
     };
 
-    // Note: href is used to determine if the user has access to the page
+    // Note: href is used to determine if the user has access to the page in
+    // defaultMenuItemsFilteredByPolicy so we need to keep it in the item although we don't use it in the render.
     const defaultMenuItems: EuiSideNavItemType<object>[] = [
         {
             name: t('start'),

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useState } from 'react';
 
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 import { EuiSideNav, EuiSpacer } from '@elastic/eui';
@@ -10,7 +9,7 @@ import { EuiSideNavItemType } from '@elastic/eui/src/components/side_nav/side_na
 import { WfoIsAllowedToRender } from '@/components';
 import { WfoStartWorkflowButtonComboBox } from '@/components/WfoStartButton/WfoStartWorkflowComboBox';
 import { PolicyResource } from '@/configuration/policy-resources';
-import { usePolicy, useWithOrchestratorTheme } from '@/hooks';
+import { usePolicy } from '@/hooks';
 
 import {
     PATH_METADATA,
@@ -26,7 +25,7 @@ import {
     PATH_WORKFLOWS,
 } from '../paths';
 import { WfoCopyright } from './WfoCopyright';
-import { getMenuItemStyles } from './styles';
+import { WfoMenuItemLink } from './WfoMenuLink';
 
 export const renderEmptyElementWhenNotAllowedByPolicy = (isAllowed: boolean) =>
     isAllowed ? undefined : () => <></>;
@@ -43,42 +42,6 @@ export type WfoSidebarProps = {
     overrideMenuItems?: (
         defaultMenuItems: EuiSideNavItemType<object>[],
     ) => EuiSideNavItemType<object>[];
-};
-
-type MenuItemProps = {
-    path: string;
-    translationString: string;
-    isSelected: boolean;
-    isSubItem?: boolean;
-};
-
-const MenuItemLink: FC<MenuItemProps> = ({
-    path,
-    translationString,
-    isSelected,
-    isSubItem,
-}) => {
-    const {
-        menuItemStyle,
-        selectedMenuItem,
-        selectedSubMenuItem,
-        subMenuItemStyle,
-    } = useWithOrchestratorTheme(getMenuItemStyles);
-
-    const getMenuItemStyle = () => {
-        if (isSubItem) {
-            return isSelected ? selectedSubMenuItem : subMenuItemStyle;
-        } else {
-            return isSelected ? selectedMenuItem : menuItemStyle;
-        }
-    };
-
-    const t = useTranslations('main');
-    return (
-        <Link css={getMenuItemStyle()} href={path}>
-            {t(translationString)}
-        </Link>
-    );
 };
 
 export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
@@ -101,7 +64,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             isSelected: router.pathname === PATH_START,
             href: PATH_START,
             renderItem: () => (
-                <MenuItemLink
+                <WfoMenuItemLink
                     path={PATH_START}
                     translationString="start"
                     isSelected={router.pathname === PATH_START}
@@ -114,7 +77,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             isSelected: router.pathname === PATH_WORKFLOWS,
             href: PATH_WORKFLOWS,
             renderItem: () => (
-                <MenuItemLink
+                <WfoMenuItemLink
                     path={PATH_WORKFLOWS}
                     translationString="workflows"
                     isSelected={router.pathname === PATH_WORKFLOWS}
@@ -127,7 +90,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             isSelected: router.pathname === PATH_SUBSCRIPTIONS,
             href: PATH_SUBSCRIPTIONS,
             renderItem: () => (
-                <MenuItemLink
+                <WfoMenuItemLink
                     path={PATH_SUBSCRIPTIONS}
                     translationString="subscriptions"
                     isSelected={router.pathname === PATH_SUBSCRIPTIONS}
@@ -142,7 +105,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                 router.pathname.substring(0, PATH_METADATA.length) ===
                 PATH_METADATA,
             renderItem: () => (
-                <MenuItemLink
+                <WfoMenuItemLink
                     path={PATH_METADATA_PRODUCTS}
                     translationString="metadata"
                     isSelected={
@@ -157,7 +120,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     id: '5.1',
                     href: PATH_METADATA_PRODUCTS,
                     renderItem: () => (
-                        <MenuItemLink
+                        <WfoMenuItemLink
                             path={PATH_METADATA_PRODUCTS}
                             translationString="metadataProducts"
                             isSelected={
@@ -174,7 +137,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                         router.pathname === PATH_METADATA_PRODUCT_BLOCKS,
                     href: PATH_METADATA_PRODUCT_BLOCKS,
                     renderItem: () => (
-                        <MenuItemLink
+                        <WfoMenuItemLink
                             path={PATH_METADATA_PRODUCT_BLOCKS}
                             translationString="metadataProductblocks"
                             isSelected={
@@ -191,7 +154,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     isSelected:
                         router.pathname === PATH_METADATA_RESOURCE_TYPES,
                     renderItem: () => (
-                        <MenuItemLink
+                        <WfoMenuItemLink
                             path={PATH_METADATA_RESOURCE_TYPES}
                             translationString="metadataResourceTypes"
                             isSelected={
@@ -207,7 +170,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     isSelected: router.pathname === PATH_METADATA_WORKFLOWS,
                     href: PATH_METADATA_WORKFLOWS,
                     renderItem: () => (
-                        <MenuItemLink
+                        <WfoMenuItemLink
                             path={PATH_METADATA_WORKFLOWS}
                             translationString="metadataWorkflows"
                             isSelected={
@@ -223,7 +186,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     isSelected: router.pathname === PATH_METADATA_TASKS,
                     href: PATH_METADATA_TASKS,
                     renderItem: () => (
-                        <MenuItemLink
+                        <WfoMenuItemLink
                             path={PATH_METADATA_TASKS}
                             translationString="metadataTasks"
                             isSelected={router.pathname === PATH_METADATA_TASKS}
@@ -239,7 +202,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             id: '6',
             href: PATH_TASKS,
             renderItem: () => (
-                <MenuItemLink
+                <WfoMenuItemLink
                     path={PATH_TASKS}
                     translationString="tasks"
                     isSelected={router.pathname === PATH_TASKS}
@@ -252,7 +215,7 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             id: '7',
             href: PATH_SETTINGS,
             renderItem: () => (
-                <MenuItemLink
+                <WfoMenuItemLink
                     path={PATH_SETTINGS}
                     translationString="settings"
                     isSelected={router.pathname === PATH_SETTINGS}

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
@@ -1,15 +1,16 @@
 import React, { FC, useState } from 'react';
 
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import { EuiSideNav, EuiSpacer } from '@elastic/eui';
+import { EuiButtonEmpty, EuiSideNav, EuiSpacer } from '@elastic/eui';
 import { EuiSideNavItemType } from '@elastic/eui/src/components/side_nav/side_nav_types';
 
 import { WfoIsAllowedToRender } from '@/components';
 import { WfoStartWorkflowButtonComboBox } from '@/components/WfoStartButton/WfoStartWorkflowComboBox';
 import { PolicyResource } from '@/configuration/policy-resources';
-import { usePolicy } from '@/hooks';
+import { usePolicy, useWithOrchestratorTheme } from '@/hooks';
 
 import {
     PATH_METADATA,
@@ -25,6 +26,7 @@ import {
     PATH_WORKFLOWS,
 } from '../paths';
 import { WfoCopyright } from './WfoCopyright';
+import { getMenuItemStyles } from './styles';
 
 export const renderEmptyElementWhenNotAllowedByPolicy = (isAllowed: boolean) =>
     isAllowed ? undefined : () => <></>;
@@ -53,87 +55,115 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
         setIsSideNavOpenOnMobile((openState) => !openState);
     };
 
+    // Note: href is used to determine if the user has access to the page
     const defaultMenuItems: EuiSideNavItemType<object>[] = [
         {
             name: t('start'),
             id: '2',
             isSelected: router.pathname === PATH_START,
-            onClick: (e) => {
-                e.preventDefault();
-                router.push(PATH_START);
-            },
+            href: PATH_START,
+            renderItem: (props) => (
+                <Link className={props.className} href={PATH_START}>
+                    {t('start')}
+                </Link>
+            ),
         },
         {
             name: t('workflows'),
             id: '3',
             isSelected: router.pathname === PATH_WORKFLOWS,
-            onClick: (e) => {
-                e.preventDefault();
-                router.push(PATH_WORKFLOWS);
-            },
+            href: PATH_WORKFLOWS,
+            renderItem: (props) => (
+                <Link className={props.className} href={PATH_WORKFLOWS}>
+                    {t('workflows')}
+                </Link>
+            ),
         },
         {
             name: t('subscriptions'),
             id: '4',
             isSelected: router.pathname === PATH_SUBSCRIPTIONS,
-            onClick: (e) => {
-                e.preventDefault();
-                router.push(PATH_SUBSCRIPTIONS);
-            },
+            renderItem: (props) => (
+                <Link className={props.className} href={PATH_SUBSCRIPTIONS}>
+                    {t('subscriptions')}
+                </Link>
+            ),
         },
         {
             name: t('metadata'),
             id: '5',
-            onClick: () => {
-                router.push(PATH_METADATA);
-            },
+            renderItem: (props) => (
+                <Link className={props.className} href={PATH_METADATA}>
+                    {t('metadata')}
+                </Link>
+            ),
             items: [
                 {
                     name: t('metadataProducts'),
                     id: '5.1',
                     isSelected: router.pathname === PATH_METADATA_PRODUCTS,
-                    onClick: (e) => {
-                        e.preventDefault();
-                        router.push(PATH_METADATA_PRODUCTS);
-                    },
+                    renderItem: (props) => (
+                        <Link
+                            className={props.className}
+                            href={PATH_METADATA_PRODUCTS}
+                        >
+                            {t('metadataProducts')}
+                        </Link>
+                    ),
                 },
                 {
                     name: t('metadataProductblocks'),
                     id: '5.2',
                     isSelected:
                         router.pathname === PATH_METADATA_PRODUCT_BLOCKS,
-                    onClick: (e) => {
-                        e.preventDefault();
-                        router.push(PATH_METADATA_PRODUCT_BLOCKS);
-                    },
+                    renderItem: (props) => (
+                        <Link
+                            className={props.className}
+                            href={PATH_METADATA_PRODUCT_BLOCKS}
+                        >
+                            {t('metadataProductblocks')}
+                        </Link>
+                    ),
                 },
                 {
                     name: t('metadataResourceTypes'),
                     id: '5.3',
                     isSelected:
                         router.pathname === PATH_METADATA_RESOURCE_TYPES,
-                    onClick: (e) => {
-                        e.preventDefault();
-                        router.push(PATH_METADATA_RESOURCE_TYPES);
-                    },
+                    renderItem: (props) => (
+                        <Link
+                            className={props.className}
+                            href={PATH_METADATA_RESOURCE_TYPES}
+                        >
+                            {t('metadataResourceTypes')}
+                        </Link>
+                    ),
                 },
                 {
                     name: t('metadataWorkflows'),
                     id: '5.4',
                     isSelected: router.pathname === PATH_METADATA_WORKFLOWS,
-                    onClick: (e) => {
-                        e.preventDefault();
-                        router.push(PATH_METADATA_WORKFLOWS);
-                    },
+                    renderItem: (props) => (
+                        <Link
+                            className={props.className}
+                            href={PATH_METADATA_WORKFLOWS}
+                        >
+                            {t('metadataWorkflows')}
+                        </Link>
+                    ),
                 },
                 {
                     name: t('metadataTasks'),
                     id: '5.5',
                     isSelected: router.pathname === PATH_METADATA_TASKS,
-                    onClick: (e) => {
-                        e.preventDefault();
-                        router.push(PATH_METADATA_TASKS);
-                    },
+                    renderItem: (props) => (
+                        <Link
+                            className={props.className}
+                            href={PATH_METADATA_TASKS}
+                        >
+                            {t('metadataTasks')}
+                        </Link>
+                    ),
                 },
             ],
         },
@@ -141,19 +171,21 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             name: t('tasks'),
             isSelected: router.pathname === PATH_TASKS,
             id: '6',
-            onClick: (e) => {
-                e.preventDefault();
-                router.push(PATH_TASKS);
-            },
+            renderItem: (props) => (
+                <Link className={props.className} href={PATH_TASKS}>
+                    {t('tasks')}
+                </Link>
+            ),
         },
         {
             name: t('settings'),
             isSelected: router.pathname === PATH_SETTINGS,
             id: '7',
-            onClick: (e) => {
-                e.preventDefault();
-                router.push(PATH_SETTINGS);
-            },
+            renderItem: (props) => (
+                <Link className={props.className} href={PATH_SETTINGS}>
+                    {t('settings')}
+                </Link>
+            ),
         },
     ];
 

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
@@ -67,7 +67,6 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             name: t('workflows'),
             id: '3',
             isSelected: router.pathname === PATH_WORKFLOWS,
-            href: PATH_WORKFLOWS,
             onClick: (e) => {
                 e.preventDefault();
                 router.push(PATH_WORKFLOWS);
@@ -77,7 +76,6 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             name: t('subscriptions'),
             id: '4',
             isSelected: router.pathname === PATH_SUBSCRIPTIONS,
-            href: PATH_SUBSCRIPTIONS,
             onClick: (e) => {
                 e.preventDefault();
                 router.push(PATH_SUBSCRIPTIONS);
@@ -86,7 +84,6 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
         {
             name: t('metadata'),
             id: '5',
-            href: PATH_METADATA,
             onClick: () => {
                 router.push(PATH_METADATA);
             },
@@ -148,7 +145,6 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                 e.preventDefault();
                 router.push(PATH_TASKS);
             },
-            href: PATH_TASKS,
         },
         {
             name: t('settings'),
@@ -158,7 +154,6 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                 e.preventDefault();
                 router.push(PATH_SETTINGS);
             },
-            href: PATH_SETTINGS,
         },
     ];
 

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
@@ -49,18 +49,33 @@ type MenuItemProps = {
     path: string;
     translationString: string;
     isSelected: boolean;
+    isSubItem?: boolean;
 };
 
 const MenuItemLink: FC<MenuItemProps> = ({
     path,
     translationString,
     isSelected,
+    isSubItem,
 }) => {
+    const {
+        menuItemStyle,
+        selectedMenuItem,
+        selectedSubMenuItem,
+        subMenuItemStyle,
+    } = useWithOrchestratorTheme(getMenuItemStyles);
+
+    const getMenuItemStyle = () => {
+        if (isSubItem) {
+            return isSelected ? selectedSubMenuItem : subMenuItemStyle;
+        } else {
+            return isSelected ? selectedMenuItem : menuItemStyle;
+        }
+    };
+
     const t = useTranslations('main');
-    const { menuItemStyle, selectedMenuItem } =
-        useWithOrchestratorTheme(getMenuItemStyles);
     return (
-        <Link css={isSelected ? selectedMenuItem : menuItemStyle} href={path}>
+        <Link css={getMenuItemStyle()} href={path}>
             {t(translationString)}
         </Link>
     );
@@ -123,26 +138,32 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             name: t('metadata'),
             id: '5',
             href: PATH_METADATA,
+            isSelected:
+                router.pathname.substring(0, PATH_METADATA.length) ===
+                PATH_METADATA,
             renderItem: () => (
                 <MenuItemLink
-                    path={PATH_METADATA}
+                    path={PATH_METADATA_PRODUCTS}
                     translationString="metadata"
-                    isSelected={router.pathname === PATH_METADATA}
+                    isSelected={
+                        router.pathname.substring(0, PATH_METADATA.length) ===
+                        PATH_METADATA
+                    }
                 />
             ),
             items: [
                 {
                     name: t('metadataProducts'),
                     id: '5.1',
-                    isSelected: router.pathname === PATH_METADATA_PRODUCTS,
                     href: PATH_METADATA_PRODUCTS,
                     renderItem: () => (
                         <MenuItemLink
-                            path={PATH_METADATA}
+                            path={PATH_METADATA_PRODUCTS}
                             translationString="metadataProducts"
                             isSelected={
                                 router.pathname === PATH_METADATA_PRODUCTS
                             }
+                            isSubItem={true}
                         />
                     ),
                 },
@@ -152,13 +173,15 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     isSelected:
                         router.pathname === PATH_METADATA_PRODUCT_BLOCKS,
                     href: PATH_METADATA_PRODUCT_BLOCKS,
-                    renderItem: (props) => (
-                        <Link
-                            className={props.className}
-                            href={PATH_METADATA_PRODUCT_BLOCKS}
-                        >
-                            {t('metadataProductblocks')}
-                        </Link>
+                    renderItem: () => (
+                        <MenuItemLink
+                            path={PATH_METADATA_PRODUCT_BLOCKS}
+                            translationString="metadataProductblocks"
+                            isSelected={
+                                router.pathname === PATH_METADATA_PRODUCT_BLOCKS
+                            }
+                            isSubItem={true}
+                        />
                     ),
                 },
                 {
@@ -167,13 +190,15 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     href: PATH_METADATA_RESOURCE_TYPES,
                     isSelected:
                         router.pathname === PATH_METADATA_RESOURCE_TYPES,
-                    renderItem: (props) => (
-                        <Link
-                            className={props.className}
-                            href={PATH_METADATA_RESOURCE_TYPES}
-                        >
-                            {t('metadataResourceTypes')}
-                        </Link>
+                    renderItem: () => (
+                        <MenuItemLink
+                            path={PATH_METADATA_RESOURCE_TYPES}
+                            translationString="metadataResourceTypes"
+                            isSelected={
+                                router.pathname === PATH_METADATA_RESOURCE_TYPES
+                            }
+                            isSubItem={true}
+                        />
                     ),
                 },
                 {
@@ -181,13 +206,15 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     id: '5.4',
                     isSelected: router.pathname === PATH_METADATA_WORKFLOWS,
                     href: PATH_METADATA_WORKFLOWS,
-                    renderItem: (props) => (
-                        <Link
-                            className={props.className}
-                            href={PATH_METADATA_WORKFLOWS}
-                        >
-                            {t('metadataWorkflows')}
-                        </Link>
+                    renderItem: () => (
+                        <MenuItemLink
+                            path={PATH_METADATA_WORKFLOWS}
+                            translationString="metadataWorkflows"
+                            isSelected={
+                                router.pathname === PATH_METADATA_WORKFLOWS
+                            }
+                            isSubItem={true}
+                        />
                     ),
                 },
                 {
@@ -195,13 +222,13 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     id: '5.5',
                     isSelected: router.pathname === PATH_METADATA_TASKS,
                     href: PATH_METADATA_TASKS,
-                    renderItem: (props) => (
-                        <Link
-                            className={props.className}
-                            href={PATH_METADATA_TASKS}
-                        >
-                            {t('metadataTasks')}
-                        </Link>
+                    renderItem: () => (
+                        <MenuItemLink
+                            path={PATH_METADATA_TASKS}
+                            translationString="metadataTasks"
+                            isSelected={router.pathname === PATH_METADATA_TASKS}
+                            isSubItem={true}
+                        />
                     ),
                 },
             ],

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/WfoSidebar.tsx
@@ -10,7 +10,7 @@ import { EuiSideNavItemType } from '@elastic/eui/src/components/side_nav/side_na
 import { WfoIsAllowedToRender } from '@/components';
 import { WfoStartWorkflowButtonComboBox } from '@/components/WfoStartButton/WfoStartWorkflowComboBox';
 import { PolicyResource } from '@/configuration/policy-resources';
-import { usePolicy } from '@/hooks';
+import { usePolicy, useWithOrchestratorTheme } from '@/hooks';
 
 import {
     PATH_METADATA,
@@ -26,6 +26,7 @@ import {
     PATH_WORKFLOWS,
 } from '../paths';
 import { WfoCopyright } from './WfoCopyright';
+import { getMenuItemStyles } from './styles';
 
 export const renderEmptyElementWhenNotAllowedByPolicy = (isAllowed: boolean) =>
     isAllowed ? undefined : () => <></>;
@@ -44,9 +45,31 @@ export type WfoSidebarProps = {
     ) => EuiSideNavItemType<object>[];
 };
 
+type MenuItemProps = {
+    path: string;
+    translationString: string;
+    isSelected: boolean;
+};
+
+const MenuItemLink: FC<MenuItemProps> = ({
+    path,
+    translationString,
+    isSelected,
+}) => {
+    const t = useTranslations('main');
+    const { menuItemStyle, selectedMenuItem } =
+        useWithOrchestratorTheme(getMenuItemStyles);
+    return (
+        <Link css={isSelected ? selectedMenuItem : menuItemStyle} href={path}>
+            {t(translationString)}
+        </Link>
+    );
+};
+
 export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
     const t = useTranslations('main');
     const router = useRouter();
+
     const [isSideNavOpenOnMobile, setIsSideNavOpenOnMobile] = useState(false);
     const { isAllowed } = usePolicy();
 
@@ -62,10 +85,12 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             id: '2',
             isSelected: router.pathname === PATH_START,
             href: PATH_START,
-            renderItem: (props) => (
-                <Link className={props.className} href={PATH_START}>
-                    {t('start')}
-                </Link>
+            renderItem: () => (
+                <MenuItemLink
+                    path={PATH_START}
+                    translationString="start"
+                    isSelected={router.pathname === PATH_START}
+                />
             ),
         },
         {
@@ -73,10 +98,12 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             id: '3',
             isSelected: router.pathname === PATH_WORKFLOWS,
             href: PATH_WORKFLOWS,
-            renderItem: (props) => (
-                <Link className={props.className} href={PATH_WORKFLOWS}>
-                    {t('workflows')}
-                </Link>
+            renderItem: () => (
+                <MenuItemLink
+                    path={PATH_WORKFLOWS}
+                    translationString="workflows"
+                    isSelected={router.pathname === PATH_WORKFLOWS}
+                />
             ),
         },
         {
@@ -84,20 +111,24 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             id: '4',
             isSelected: router.pathname === PATH_SUBSCRIPTIONS,
             href: PATH_SUBSCRIPTIONS,
-            renderItem: (props) => (
-                <Link className={props.className} href={PATH_SUBSCRIPTIONS}>
-                    {t('subscriptions')}
-                </Link>
+            renderItem: () => (
+                <MenuItemLink
+                    path={PATH_SUBSCRIPTIONS}
+                    translationString="subscriptions"
+                    isSelected={router.pathname === PATH_SUBSCRIPTIONS}
+                />
             ),
         },
         {
             name: t('metadata'),
             id: '5',
             href: PATH_METADATA,
-            renderItem: (props) => (
-                <Link className={props.className} href={PATH_METADATA}>
-                    {t('metadata')}
-                </Link>
+            renderItem: () => (
+                <MenuItemLink
+                    path={PATH_METADATA}
+                    translationString="metadata"
+                    isSelected={router.pathname === PATH_METADATA}
+                />
             ),
             items: [
                 {
@@ -105,13 +136,14 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
                     id: '5.1',
                     isSelected: router.pathname === PATH_METADATA_PRODUCTS,
                     href: PATH_METADATA_PRODUCTS,
-                    renderItem: (props) => (
-                        <Link
-                            className={props.className}
-                            href={PATH_METADATA_PRODUCTS}
-                        >
-                            {t('metadataProducts')}
-                        </Link>
+                    renderItem: () => (
+                        <MenuItemLink
+                            path={PATH_METADATA}
+                            translationString="metadataProducts"
+                            isSelected={
+                                router.pathname === PATH_METADATA_PRODUCTS
+                            }
+                        />
                     ),
                 },
                 {
@@ -179,10 +211,12 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             isSelected: router.pathname === PATH_TASKS,
             id: '6',
             href: PATH_TASKS,
-            renderItem: (props) => (
-                <Link className={props.className} href={PATH_TASKS}>
-                    {t('tasks')}
-                </Link>
+            renderItem: () => (
+                <MenuItemLink
+                    path={PATH_TASKS}
+                    translationString="tasks"
+                    isSelected={router.pathname === PATH_TASKS}
+                />
             ),
         },
         {
@@ -190,10 +224,12 @@ export const WfoSidebar: FC<WfoSidebarProps> = ({ overrideMenuItems }) => {
             isSelected: router.pathname === PATH_SETTINGS,
             id: '7',
             href: PATH_SETTINGS,
-            renderItem: (props) => (
-                <Link className={props.className} href={PATH_SETTINGS}>
-                    {t('settings')}
-                </Link>
+            renderItem: () => (
+                <MenuItemLink
+                    path={PATH_SETTINGS}
+                    translationString="settings"
+                    isSelected={router.pathname === PATH_SETTINGS}
+                />
             ),
         },
     ];

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/index.ts
@@ -1,1 +1,2 @@
 export * from './WfoSidebar';
+export * from './WfoMenuLink';

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/styles.ts
@@ -1,5 +1,5 @@
 import { EuiThemeComputed } from '@elastic/eui';
-import { css } from '@emotion/react';
+import { CSSObject, css } from '@emotion/react';
 
 export const getCopyrightStyles = (theme: EuiThemeComputed) => {
     const copyrightStyle = css({
@@ -17,28 +17,62 @@ export const getCopyrightStyles = (theme: EuiThemeComputed) => {
 };
 
 export const getMenuItemStyles = (theme: EuiThemeComputed) => {
-    const menuItemStyle = css({
-        color: theme.colors.title,
-        padding: `${theme.base * 0.625}px ${theme.base * 0.75}px`,
+    const baseStyles: CSSObject = {
+        lineHeight: `${theme.base * 1.25}px`,
         display: 'flex',
         alignItems: 'center',
         ':hover': {
             textDecoration: 'underline',
         },
+        color: theme.colors.text,
+        padding: `${theme.base * 0.5}px ${theme.base * 0.75}px`,
+    };
+
+    const baseSubMenuStyles: CSSObject = {
+        ...baseStyles,
+        ':after': {
+            content: "''",
+            top: '16px',
+            left: 0,
+            width: '4px',
+            height: '1px',
+            backgroundColor: '#d3dae6',
+            position: 'absolute',
+        },
+        padding: '8px 12px',
+        ':last-child': {
+            top: '-4px',
+            position: 'relative',
+        },
+    };
+
+    const menuItemStyle = css({
+        ...baseStyles,
+        color: theme.colors.title,
     });
 
     const selectedMenuItem = css({
+        ...baseStyles,
         height: `${theme.base * 2.25}px`,
         backgroundColor: theme.colors.lightShade,
         borderRadius: theme.border.radius.medium,
-        padding: `${theme.base * 0.5}px ${theme.base * 0.75}px`,
-        display: 'flex',
-        alignItems: 'center',
         fontWeight: theme.font.weight.semiBold,
+        color: theme.colors.primaryText,
+    });
+
+    const selectedSubMenuItem = css({
+        ...baseSubMenuStyles,
+        fontWeight: theme.font.weight.semiBold,
+    });
+
+    const subMenuItemStyle = css({
+        ...baseSubMenuStyles,
     });
 
     return {
         menuItemStyle,
         selectedMenuItem,
+        selectedSubMenuItem,
+        subMenuItemStyle,
     };
 };

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoSidebar/styles.ts
@@ -15,3 +15,30 @@ export const getCopyrightStyles = (theme: EuiThemeComputed) => {
         copyrightStyle,
     };
 };
+
+export const getMenuItemStyles = (theme: EuiThemeComputed) => {
+    const menuItemStyle = css({
+        color: theme.colors.title,
+        padding: `${theme.base * 0.625}px ${theme.base * 0.75}px`,
+        display: 'flex',
+        alignItems: 'center',
+        ':hover': {
+            textDecoration: 'underline',
+        },
+    });
+
+    const selectedMenuItem = css({
+        height: `${theme.base * 2.25}px`,
+        backgroundColor: theme.colors.lightShade,
+        borderRadius: theme.border.radius.medium,
+        padding: `${theme.base * 0.5}px ${theme.base * 0.75}px`,
+        display: 'flex',
+        alignItems: 'center',
+        fontWeight: theme.font.weight.semiBold,
+    });
+
+    return {
+        menuItemStyle,
+        selectedMenuItem,
+    };
+};


### PR DESCRIPTION
Ticket: https://github.com/workfloworchestrator/orchestrator-ui-library/issues/905
Improves sideNav functionality by
- Preventing a page reload when clicking on Metadata
- Keeping standard navigating behaviour like middle mouse click/command click opening a link in another tab in the background by using a link instead of an onclick handler.

There is a small difference in how the menu item renders when it's selected now that I still have to discuss with @wouter1975 