### PR TITLE
Deprecate axios version of UserInputFormWizard and useFilterQueryWithRest

### DIFF
--- a/.changeset/dull-tables-poke.md
+++ b/.changeset/dull-tables-poke.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": minor
+---
+
+Deprecate apiclient version of UserInputFormWizard

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,11 @@
                 "@elastic/eui": "^93.1.1",
                 "@emotion/css": "^11.11.2",
                 "@emotion/react": "^11.11.1",
+                "@graphql-typed-document-node/core": "3.2.0",
                 "@orchestrator-ui/orchestrator-ui-components": "*",
                 "@reduxjs/toolkit": "^2.0.1",
+                "graphql": "^16.8.1",
+                "graphql-request": "^6.1.0",
                 "moment": "^2.29.4",
                 "next": "^14.0.4",
                 "next-auth": "^4.24.5",
@@ -53,7 +56,7 @@
             }
         },
         "apps/wfo-ui-surf": {
-            "version": "0.3.6",
+            "version": "1.0.5",
             "dependencies": {
                 "@elastic/datemath": "^5.0.3",
                 "@elastic/eui": "^93.1.1",
@@ -86,6 +89,7 @@
                 "@types/react-dom": "^18.2.18",
                 "@types/react-no-ssr": "^1.1.7",
                 "esbuild-jest": "^0.5.0",
+                "husky": "^9.0.11",
                 "typescript": "^5.3.2"
             }
         },
@@ -16292,7 +16296,6 @@
             "version": "16.8.1",
             "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
             "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
@@ -29815,8 +29818,8 @@
         },
         "packages/eslint-config-custom": {
             "name": "@orchestrator-ui/eslint-config-custom",
-            "version": "1.1.3",
-            "license": "MIT",
+            "version": "1.2.1",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@trivago/prettier-plugin-sort-imports": "^4.3.0",
                 "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -29981,8 +29984,8 @@
         },
         "packages/jest-config": {
             "name": "@orchestrator-ui/jest-config",
-            "version": "1.1.0",
-            "license": "MIT",
+            "version": "1.2.1",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@testing-library/jest-dom": "^6.1.5",
                 "@testing-library/react": "^14.0.0",
@@ -30473,8 +30476,8 @@
         },
         "packages/orchestrator-ui-components": {
             "name": "@orchestrator-ui/orchestrator-ui-components",
-            "version": "1.3.1",
-            "license": "MIT",
+            "version": "1.6.0",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@emotion/css": "^11.11.2",
                 "@emotion/react": "^11.11.1",
@@ -31092,8 +31095,8 @@
         },
         "packages/tsconfig": {
             "name": "@orchestrator-ui/tsconfig",
-            "version": "1.0.0",
-            "license": "MIT"
+            "version": "1.1.1",
+            "license": "Apache-2.0"
         }
     }
 }

--- a/packages/orchestrator-ui-components/src/components/WfoForms/CreateForm.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/CreateForm.tsx
@@ -16,7 +16,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { Form, FormNotCompleteResponse } from '@/types/forms';
 
-import UserInputFormWizard from './UserInputFormWizard';
+import UserInputFormWizardDeprecated from './UserInputFormWizardDeprecated';
 import { useAxiosApiClient } from './useAxiosApiClient';
 
 interface IProps {
@@ -60,7 +60,7 @@ export function CreateForm(props: IProps) {
     return (
         <div>
             {stepUserInput && (
-                <UserInputFormWizard
+                <UserInputFormWizardDeprecated
                     stepUserInput={stepUserInput}
                     validSubmit={submit}
                     cancel={handleCancel}

--- a/packages/orchestrator-ui-components/src/components/WfoForms/UserInputFormWizardDeprecated.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/UserInputFormWizardDeprecated.tsx
@@ -80,9 +80,7 @@ export function UserInputFormWizardDeprecated({
             result,
             510,
             (json) => {
-                // Scroll to top when navigating to next screen of wizard
                 window.scrollTo(0, 0);
-                // setFlash(intl.formatMessage({ id: "process.flash.wizard_next_step" }));
                 setForms([
                     ...forms,
                     { form: json.form, hasNext: json.hasNext },

--- a/packages/orchestrator-ui-components/src/components/WfoForms/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/index.ts
@@ -1,5 +1,6 @@
 export * from './AutoFields';
 export * from './UserInputForm';
 export * from './UserInputFormWizard';
+export * from './UserInputFormWizardDeprecated';
 export * from './formFields';
 export * from './CreateForm';

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStepForm.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStepForm.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { EuiFlexItem } from '@elastic/eui';
 
-import { UserInputFormWizard, WfoLoading } from '@/components';
+import { UserInputFormWizardDeprecated, WfoLoading } from '@/components';
 import { useAxiosApiClient } from '@/components/WfoForms/useAxiosApiClient';
 import { useOrchestratorTheme } from '@/hooks';
 import { InputForm } from '@/types/forms';
@@ -35,7 +35,7 @@ export const WfoStepForm = ({
     return (
         <EuiFlexItem css={{ margin: theme.size.m }}>
             {(isProcessing && <WfoLoading />) || (
-                <UserInputFormWizard
+                <UserInputFormWizardDeprecated
                     stepUserInput={userInputForm}
                     validSubmit={submitForm}
                     hasNext={false}

--- a/packages/orchestrator-ui-components/src/hooks/DataFetchHooks.ts
+++ b/packages/orchestrator-ui-components/src/hooks/DataFetchHooks.ts
@@ -42,6 +42,10 @@ export const filterDataByCriteria = <Type>(
     });
 };
 
+/**
+ * @deprecated
+ * Currently not in use in the SURF app - switched to RTK Query
+ */
 export const useFilterQueryWithRest = <Type>(
     url: string,
     queryKey: string[],

--- a/packages/orchestrator-ui-components/src/pages/processes/WfoStartProcessPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/processes/WfoStartProcessPage.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/types';
 import { FormNotCompleteResponse } from '@/types/forms';
 
-import UserInputFormWizard from '../../components/WfoForms/UserInputFormWizard';
+import UserInputFormWizardDeprecated from '../../components/WfoForms/UserInputFormWizardDeprecated';
 import { WfoProcessDetail } from './WfoProcessDetail';
 
 type StartCreateWorkflowPayload = {
@@ -215,7 +215,7 @@ export const WfoStartProcessPage = ({
                 <EuiHorizontalRule />
                 {(hasError && <WfoError />) ||
                     (stepUserInput && (
-                        <UserInputFormWizard
+                        <UserInputFormWizardDeprecated
                             stepUserInput={stepUserInput}
                             validSubmit={submit}
                             cancel={() =>

--- a/packages/orchestrator-ui-components/src/rtk/api.ts
+++ b/packages/orchestrator-ui-components/src/rtk/api.ts
@@ -21,6 +21,12 @@ export enum CacheTags {
     subscriptionList = 'subscriptionList',
 }
 
+export enum HttpStatus {
+    FormNotComplete = 510,
+    BadGateway = 502,
+    BadRequest = 400,
+}
+
 type ExtraOptions = {
     baseQueryType?: BaseQueryTypes;
     apiName?: string;
@@ -32,6 +38,20 @@ export const prepareHeaders = async (headers: Headers) => {
         headers.set('Authorization', `Bearer ${session.accessToken}`);
     }
     return headers;
+};
+
+export const handlePromiseErrorWithCallback = <T>(
+    promise: Promise<unknown>,
+    status: number,
+    callbackAction: (json: T) => void,
+) => {
+    return promise.catch((err) => {
+        if (err.data && err.status === status) {
+            callbackAction(err.data);
+        } else {
+            throw err;
+        }
+    });
 };
 
 export const orchestratorApi = createApi({


### PR DESCRIPTION
Renamed the old UserInputFormWizard to UserInputFormWizardDeprecated which uses the axios apiClient. The new one is currently used with CIM forms.