### PR TITLE
879 overridable summarycards

### DIFF
--- a/.changeset/ten-scissors-hide.md
+++ b/.changeset/ten-scissors-hide.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+879 Makes SummaryCards on the start page overridable

--- a/packages/orchestrator-ui-components/src/pages/startPage/WfoStartPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/startPage/WfoStartPage.tsx
@@ -26,8 +26,12 @@ import {
 } from '@/types';
 import { formatDate } from '@/utils';
 
+import { useStartPageSummaryCardConfigurationOverride } from './useStartPageSummaryCardConfigurationOverride';
+
 export const WfoStartPage = () => {
     const t = useTranslations('startPage');
+    const { overrideSummaryCards } =
+        useStartPageSummaryCardConfigurationOverride();
     const { isAllowed } = usePolicy();
 
     const {
@@ -177,9 +181,12 @@ export const WfoStartPage = () => {
         productsSummaryCard,
     ];
 
+    const summaryCards =
+        overrideSummaryCards?.(allowedSummaryCards) || allowedSummaryCards;
+
     return (
         <EuiFlexItem>
-            <WfoSummaryCards summaryCards={allowedSummaryCards} />
+            <WfoSummaryCards summaryCards={summaryCards} />
         </EuiFlexItem>
     );
 };

--- a/packages/orchestrator-ui-components/src/pages/startPage/useStartPageSummaryCardConfigurationOverride.ts
+++ b/packages/orchestrator-ui-components/src/pages/startPage/useStartPageSummaryCardConfigurationOverride.ts
@@ -1,0 +1,13 @@
+import { useAppSelector } from '@/rtk/hooks';
+
+export const useStartPageSummaryCardConfigurationOverride = () => {
+    const overrideSummaryCards = useAppSelector(
+        (state) =>
+            state.orchestratorComponentOverride?.startPage
+                ?.summaryCardConfigurationOverride,
+    );
+
+    return {
+        overrideSummaryCards,
+    };
+};

--- a/packages/orchestrator-ui-components/src/rtk/slices/orchestratorComponentOverride.ts
+++ b/packages/orchestrator-ui-components/src/rtk/slices/orchestratorComponentOverride.ts
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 import { Slice, createSlice } from '@reduxjs/toolkit';
 
+import { SummaryCard } from '@/components/WfoSummary';
 import { FieldValue, SubscriptionDetail } from '@/types';
 
 export type ValueOverrideFunction = (fieldValue: FieldValue) => ReactNode;
@@ -13,6 +14,11 @@ export type WfoSubscriptionDetailGeneralConfiguration = {
 };
 
 export type OrchestratorComponentOverride = {
+    startPage?: {
+        summaryCardConfigurationOverride?: (
+            defaultItems: SummaryCard[],
+        ) => SummaryCard[];
+    };
     subscriptionDetail?: {
         valueOverrides?: ValueOverrideConfiguration;
         generalSectionConfigurationOverride?: (


### PR DESCRIPTION
#879 

Makes summary cards on the start page overridable