### PR TITLE
776 in use by relations

### DIFF
--- a/.changeset/ninety-stingrays-flash.md
+++ b/.changeset/ninety-stingrays-flash.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+Adds prettier output for the "In-use by subscription(s)" on product blocks on subscription details

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 
 import {
     WfoError,
@@ -9,8 +10,11 @@ import {
     WfoLoading,
 } from '@/components';
 import type { WfoKeyValueTableDataType } from '@/components';
+import { useWithOrchestratorTheme } from '@/hooks';
 import { useGetInUseByRelationDetailsQuery } from '@/rtk';
 import { InUseByRelation, InUseByRelationDetail } from '@/types';
+
+import { getStyles } from './styles';
 
 interface WfoInUseByRelationsProps {
     inUseByRelations: InUseByRelation[];
@@ -20,7 +24,7 @@ export const WfoInUseByRelations = ({
     inUseByRelations,
 }: WfoInUseByRelationsProps) => {
     const t = useTranslations('subscriptions.detail');
-
+    const { inUseByRelationDetailsStyle } = useWithOrchestratorTheme(getStyles);
     const subscriptionIds = inUseByRelations
         .map((relation) => relation.subscription_id)
         .join('|');
@@ -41,16 +45,6 @@ export const WfoInUseByRelations = ({
     ): WfoKeyValueTableDataType[] => {
         return [
             {
-                key: t('description'),
-                value: inUseByRelationDetails.description,
-                textToCopy: inUseByRelationDetails.description,
-            },
-            {
-                key: t('productType'),
-                value: inUseByRelationDetails.product.productType,
-                textToCopy: inUseByRelationDetails.product.productType,
-            },
-            {
                 key: t('subscriptionId'),
                 value: (
                     <WfoFirstPartUUID
@@ -58,6 +52,22 @@ export const WfoInUseByRelations = ({
                     />
                 ),
                 textToCopy: inUseByRelationDetails.subscriptionId,
+            },
+            {
+                key: t('description'),
+                value: (
+                    <Link
+                        href={`/subscriptions/${inUseByRelationDetails.subscriptionId}`}
+                    >
+                        {inUseByRelationDetails.description}
+                    </Link>
+                ),
+                textToCopy: inUseByRelationDetails.description,
+            },
+            {
+                key: t('productType'),
+                value: inUseByRelationDetails.product.productType,
+                textToCopy: inUseByRelationDetails.product.productType,
             },
         ];
     };
@@ -68,11 +78,12 @@ export const WfoInUseByRelations = ({
                 const keyValues = getKeyValues(relation);
 
                 return (
-                    <WfoKeyValueTable
-                        keyValues={keyValues}
-                        showCopyToClipboardIcon={true}
-                        key={index}
-                    />
+                    <div css={inUseByRelationDetailsStyle} key={index}>
+                        <WfoKeyValueTable
+                            keyValues={keyValues}
+                            showCopyToClipboardIcon={true}
+                        />
+                    </div>
                 );
             })}
         </>

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 
-import { WfoError, WfoLoading } from '@/components';
+import { useTranslations } from 'next-intl';
+
+import {
+    WfoError,
+    WfoFirstPartUUID,
+    WfoKeyValueTable,
+    WfoLoading,
+} from '@/components';
+import type { WfoKeyValueTableDataType } from '@/components';
 import { useGetInUseByRelationDetailsQuery } from '@/rtk';
-import { InUseByRelation } from '@/types';
+import { InUseByRelation, InUseByRelationDetail } from '@/types';
 
 interface WfoInUseByRelationsProps {
     inUseByRelations: InUseByRelation[];
@@ -11,13 +19,15 @@ interface WfoInUseByRelationsProps {
 export const WfoInUseByRelations = ({
     inUseByRelations,
 }: WfoInUseByRelationsProps) => {
+    const t = useTranslations('subscriptions.detail');
+
     const subscriptionIds = inUseByRelations
         .map((relation) => relation.subscription_id)
         .join('|');
     const { data, isLoading, isError } = useGetInUseByRelationDetailsQuery({
         subscriptionIds,
     });
-    console.log(data);
+
     if (isError) {
         return <WfoError />;
     }
@@ -25,5 +35,46 @@ export const WfoInUseByRelations = ({
     if (isLoading) {
         return <WfoLoading />;
     }
-    return <>WIP</>;
+
+    const getKeyValues = (
+        inUseByRelationDetails: InUseByRelationDetail,
+    ): WfoKeyValueTableDataType[] => {
+        return [
+            {
+                key: t('description'),
+                value: inUseByRelationDetails.description,
+                textToCopy: inUseByRelationDetails.description,
+            },
+            {
+                key: t('productType'),
+                value: inUseByRelationDetails.product.productType,
+                textToCopy: inUseByRelationDetails.product.productType,
+            },
+            {
+                key: t('subscriptionId'),
+                value: (
+                    <WfoFirstPartUUID
+                        UUID={inUseByRelationDetails.subscriptionId}
+                    />
+                ),
+                textToCopy: inUseByRelationDetails.subscriptionId,
+            },
+        ];
+    };
+
+    return (
+        <>
+            {data?.inUseByRelationDetails.map((relation, index) => {
+                const keyValues = getKeyValues(relation);
+
+                return (
+                    <WfoKeyValueTable
+                        keyValues={keyValues}
+                        showCopyToClipboardIcon={true}
+                        key={index}
+                    />
+                );
+            })}
+        </>
+    );
 };

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
@@ -1,20 +1,29 @@
 import React from 'react';
 
-type inUseByRelation = {
-    subscription_instance_id: string;
-    subscription_id: string;
-};
+import { WfoError, WfoLoading } from '@/components';
+import { useGetInUseByRelationDetailsQuery } from '@/rtk';
+import { InUseByRelation } from '@/types';
 
 interface WfoInUseByRelationsProps {
-    inUseByRelations: inUseByRelation[];
+    inUseByRelations: InUseByRelation[];
 }
 
 export const WfoInUseByRelations = ({
     inUseByRelations,
 }: WfoInUseByRelationsProps) => {
-    const subscriptionIds = inUseByRelations.map(
-        (relation) => relation.subscription_id,
-    );
+    const subscriptionIds = inUseByRelations
+        .map((relation) => relation.subscription_id)
+        .join('|');
+    const { data, isLoading, isError } = useGetInUseByRelationDetailsQuery({
+        subscriptionIds,
+    });
+    console.log(data);
+    if (isError) {
+        return <WfoError />;
+    }
 
-    return <div>WfoInUseBySubscriptions: {subscriptionIds.join(', ')}</div>;
+    if (isLoading) {
+        return <WfoLoading />;
+    }
+    return <>WIP</>;
 };

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
@@ -10,6 +10,7 @@ import {
     WfoLoading,
 } from '@/components';
 import type { WfoKeyValueTableDataType } from '@/components';
+import { PATH_SUBSCRIPTIONS } from '@/components';
 import { useWithOrchestratorTheme } from '@/hooks';
 import { useGetInUseByRelationDetailsQuery } from '@/rtk';
 import { InUseByRelation, InUseByRelationDetail } from '@/types';
@@ -57,7 +58,7 @@ export const WfoInUseByRelations = ({
                 key: t('description'),
                 value: (
                     <Link
-                        href={`/subscriptions/${inUseByRelationDetails.subscriptionId}`}
+                        href={`/${PATH_SUBSCRIPTIONS}/${inUseByRelationDetails.subscriptionId}`}
                     >
                         {inUseByRelationDetails.description}
                     </Link>

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
@@ -65,9 +65,9 @@ export const WfoInUseByRelations = ({
                 textToCopy: inUseByRelationDetails.description,
             },
             {
-                key: t('productType'),
-                value: inUseByRelationDetails.product.productType,
-                textToCopy: inUseByRelationDetails.product.productType,
+                key: t('productName'),
+                value: inUseByRelationDetails.product.name,
+                textToCopy: inUseByRelationDetails.product.name,
             },
         ];
     };

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type inUseByRelation = {
+    subscription_instance_id: string;
+    subscription_id: string;
+};
+
+interface WfoInUseByRelationsProps {
+    inUseByRelations: inUseByRelation[];
+}
+
+export const WfoInUseByRelations = ({
+    inUseByRelations,
+}: WfoInUseByRelationsProps) => {
+    const subscriptionIds = inUseByRelations.map(
+        (relation) => relation.subscription_id,
+    );
+
+    return <div>WfoInUseBySubscriptions: {subscriptionIds.join(', ')}</div>;
+};

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoSubscriptionProductBlock.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoSubscriptionProductBlock.tsx
@@ -14,14 +14,11 @@ import {
     EuiText,
 } from '@elastic/eui';
 
-import {
-    PATH_SUBSCRIPTIONS,
-    WfoJsonCodeBlock,
-    WfoProductBlockKeyValueRow,
-} from '@/components';
+import { PATH_SUBSCRIPTIONS, WfoProductBlockKeyValueRow } from '@/components';
 import { useOrchestratorTheme, useWithOrchestratorTheme } from '@/hooks';
 import { FieldValue, InUseByRelation } from '@/types';
 
+import { WfoInUseByRelations } from '../WfoInUseByRelations';
 import {
     getFieldFromProductBlockInstanceValues,
     getProductBlockTitle,
@@ -143,9 +140,10 @@ export const WfoSubscriptionProductBlock = ({
                                             <b>{t('inUseByRelations')}</b>
                                         </td>
                                         <td css={rightColumnStyle}>
-                                            <WfoJsonCodeBlock
-                                                data={inUseByRelations}
-                                                isBasicStyle
+                                            <WfoInUseByRelations
+                                                inUseByRelations={
+                                                    inUseByRelations
+                                                }
                                             />
                                         </td>
                                     </tr>

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoSubscriptionProductBlock.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoSubscriptionProductBlock.tsx
@@ -140,11 +140,14 @@ export const WfoSubscriptionProductBlock = ({
                                             <b>{t('inUseByRelations')}</b>
                                         </td>
                                         <td css={rightColumnStyle}>
-                                            <WfoInUseByRelations
-                                                inUseByRelations={
-                                                    inUseByRelations
-                                                }
-                                            />
+                                            {(inUseByRelations.length === 0 &&
+                                                'None') || (
+                                                <WfoInUseByRelations
+                                                    inUseByRelations={
+                                                        inUseByRelations
+                                                    }
+                                                />
+                                            )}
                                         </td>
                                     </tr>
                                 </>

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/styles.ts
@@ -43,6 +43,14 @@ export const getStyles = (theme: EuiThemeComputed) => {
         border: 0,
     });
 
+    const inUseByRelationDetailsStyle = css({
+        borderColor: theme.colors.lightShade,
+        borderStyle: 'solid',
+        borderWidth: 'thin',
+        marginBottom: theme.base / 4,
+        borderRadius: theme.border.radius.medium,
+    });
+
     return {
         contentCellStyle,
         headerCellStyle,
@@ -52,5 +60,6 @@ export const getStyles = (theme: EuiThemeComputed) => {
         emptyCellStyle,
         lastContentCellStyle,
         lastHeaderCellStyle,
+        inUseByRelationDetailsStyle,
     };
 };

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/index.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/index.ts
@@ -13,3 +13,4 @@ export * from './subscriptionDetail';
 export * from './subscriptionsDropdownOptions';
 export * from './relatedSubscriptions';
 export * from './startOptions';
+export * from './subscriptionInUseByRelationsList';

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionInUseByRelationsList.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionInUseByRelationsList.ts
@@ -1,0 +1,54 @@
+import { CacheTags, orchestratorApi } from '@/rtk';
+import { InUseByRelationDetail, InUseByRelationsDetailResult } from '@/types';
+
+export const subscriptionInUseByRelationQuery = `
+    query SubscriptionsInUseByRelationsDetails(
+        $subscriptionIds: String!
+    ) {
+        subscriptions(
+            first: 1000000
+            after: 0
+            filterBy: [{field: "subscriptionId", value: $subscriptionIds},{field: "status", value: "INITIAL|ACTIVE|MIGRATING|DISABLED|PROVISIONING"}]
+          ) {
+            page {
+              product {
+                productType
+              }
+              description
+              subscriptionId
+              status
+            }
+          }
+    }
+`;
+
+export type InUseByRelationsDetailResponse = {
+    inUseByRelationDetails: InUseByRelationDetail[];
+};
+
+const subscriptionInUseByRelationsListApi = orchestratorApi.injectEndpoints({
+    endpoints: (builder) => ({
+        getInUseByRelationDetails: builder.query<
+            InUseByRelationsDetailResponse,
+            { subscriptionIds: string }
+        >({
+            query: (variables) => ({
+                document: subscriptionInUseByRelationQuery,
+                variables,
+            }),
+            transformResponse: (
+                response: InUseByRelationsDetailResult,
+            ): InUseByRelationsDetailResponse => {
+                const subscriptions = response.subscriptions.page || [];
+
+                return {
+                    inUseByRelationDetails: subscriptions,
+                };
+            },
+            providesTags: [CacheTags.subscriptionList],
+        }),
+    }),
+});
+
+export const { useGetInUseByRelationDetailsQuery } =
+    subscriptionInUseByRelationsListApi;

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionInUseByRelationsList.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionInUseByRelationsList.ts
@@ -1,5 +1,17 @@
 import { CacheTags, orchestratorApi } from '@/rtk';
-import { InUseByRelationDetail, InUseByRelationsDetailResult } from '@/types';
+import {
+    InUseByRelationDetail,
+    InUseByRelationsDetailResult,
+    SubscriptionStatus,
+} from '@/types';
+
+const nonTerminalSubscriptionStatuses = [
+    SubscriptionStatus.INITIAL,
+    SubscriptionStatus.ACTIVE,
+    SubscriptionStatus.MIGRATING,
+    SubscriptionStatus.DISABLED,
+    SubscriptionStatus.PROVISIONING,
+].join('|');
 
 export const subscriptionInUseByRelationQuery = `
     query SubscriptionsInUseByRelationsDetails(
@@ -8,7 +20,7 @@ export const subscriptionInUseByRelationQuery = `
         subscriptions(
             first: 1000000
             after: 0
-            filterBy: [{field: "subscriptionId", value: $subscriptionIds},{field: "status", value: "INITIAL|ACTIVE|MIGRATING|DISABLED|PROVISIONING"}]
+            filterBy: [{field: "subscriptionId", value: $subscriptionIds},{field: "status", value: ${nonTerminalSubscriptionStatuses}}]
           ) {
             page {
               product {

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionInUseByRelationsList.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionInUseByRelationsList.ts
@@ -1,3 +1,4 @@
+import { NUMBER_OF_ITEMS_REPRESENTING_ALL_ITEMS } from '@/configuration';
 import { CacheTags, orchestratorApi } from '@/rtk';
 import {
     InUseByRelationDetail,
@@ -18,7 +19,7 @@ export const subscriptionInUseByRelationQuery = `
         $subscriptionIds: String!
     ) {
         subscriptions(
-            first: 1000000
+            first: ${NUMBER_OF_ITEMS_REPRESENTING_ALL_ITEMS}
             after: 0
             filterBy: [{field: "subscriptionId", value: $subscriptionIds},{field: "status", value: ${nonTerminalSubscriptionStatuses}}]
           ) {

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionInUseByRelationsList.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionInUseByRelationsList.ts
@@ -12,7 +12,7 @@ export const subscriptionInUseByRelationQuery = `
           ) {
             page {
               product {
-                productType
+                name
               }
               description
               subscriptionId

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -356,6 +356,10 @@ export interface RelatedSubscriptionsResult {
     >;
 }
 
+export interface InUseByRelationsDetailResult {
+    subscriptions: GraphQlSinglePage<InUseByRelationDetail>;
+}
+
 export type StartComboBoxOption = {
     data: {
         workflowName: string;
@@ -478,6 +482,13 @@ export type RelatedSubscription = Pick<
 > & {
     product: Pick<ProductDefinition, 'tag'>;
     customer: Pick<Customer, 'fullname'>;
+};
+
+export type InUseByRelationDetail = Pick<
+    Subscription,
+    'subscriptionId' | 'description'
+> & {
+    product: Pick<ProductDefinition, 'productType'>;
 };
 
 export type ExternalService = {

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -488,7 +488,7 @@ export type InUseByRelationDetail = Pick<
     Subscription,
     'subscriptionId' | 'description'
 > & {
-    product: Pick<ProductDefinition, 'productType'>;
+    product: Pick<ProductDefinition, 'name'>;
 };
 
 export type ExternalService = {


### PR DESCRIPTION
Replaces the jsonCode block output for the inUse by subscrtiptiosn field of the product block instance cards on the subscriptionDetail page

This is a possible follow up ticket that moves this functionality back to the backend: https://github.com/workfloworchestrator/orchestrator-ui-library/issues/1031