### PR TITLE
Configurable OAuth Scopes via Environment Variables

### DIFF
--- a/.changeset/poor-pumpkins-cry.md
+++ b/.changeset/poor-pumpkins-cry.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+1055 Making OAuth Scopes configurable via Environment Variables

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
         "NEXTAUTH_ISSUER",
         "NEXTAUTH_URL",
         "NEXTAUTH_WELL_KNOWN_OVERRIDE",
-        "NEXTATHU_AUTHORIZATION_SCOPE",
+        "NEXTAUTH_AUTHORIZATION_SCOPE",
         "AUTH_ACTIVE"
     ],
     "pipeline": {

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
         "NEXTAUTH_ISSUER",
         "NEXTAUTH_URL",
         "NEXTAUTH_WELL_KNOWN_OVERRIDE",
-        "NEXTAUTH_AUTHORIZATION_SCOPE",
+        "NEXTAUTH_AUTHORIZATION_SCOPE_OVERRIDE",
         "AUTH_ACTIVE"
     ],
     "pipeline": {

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,7 @@
         "NEXTAUTH_ISSUER",
         "NEXTAUTH_URL",
         "NEXTAUTH_WELL_KNOWN_OVERRIDE",
+        "NEXTATHU_AUTHORIZATION_SCOPE",
         "AUTH_ACTIVE"
     ],
     "pipeline": {


### PR DESCRIPTION
**Issue**:
The authorization scopes for OAuth are currently hardcoded in the NextAuth.js configuration, limiting operational flexibility across different environments.

Link to the issue: https://github.com/workfloworchestrator/orchestrator-ui-library/issues/1055