### PR TITLE
626 dark theme 2

### DIFF
--- a/.changeset/sour-bears-fold.md
+++ b/.changeset/sour-bears-fold.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": minor
+---
+
+626 Tweaks dark theme on detail pages and the settings page

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoWebsocketStatusBadge/WfoWebsocketStatusBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoWebsocketStatusBadge/WfoWebsocketStatusBadge.tsx
@@ -25,7 +25,7 @@ export const WfoWebsocketStatusBadge = () => {
             }
         >
             <WfoHeaderBadge
-                color={theme.colors.emptyShade}
+                color={theme.colors.ghost}
                 textColor={theme.colors.shadow}
                 iconType={() =>
                     websocketConnected ? (

--- a/packages/orchestrator-ui-components/src/components/WfoDiff/WfoDiff.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoDiff/WfoDiff.tsx
@@ -18,6 +18,9 @@ import {
     EuiText,
 } from '@elastic/eui';
 
+import { getWfoDiffStyles } from '@/components/WfoDiff/styles';
+import { useWithOrchestratorTheme } from '@/hooks';
+
 const EMPTY_HUNKS: never[] = [];
 
 const SMALL_CONTEXT = 3;
@@ -38,6 +41,8 @@ const WfoDiff: FC<WfoDiffProps> = ({ oldText, newText, syntax }) => {
     const t = useTranslations('processes.delta');
     const [showSplit, setShowSplit] = useState(true);
     const [showFull, setShowFull] = useState(false);
+
+    const { diffStyle } = useWithOrchestratorTheme(getWfoDiffStyles);
 
     const [{ type, hunks }, setDiff] = useState<DiffState>({
         type: 'modify',
@@ -103,6 +108,7 @@ const WfoDiff: FC<WfoDiffProps> = ({ oldText, newText, syntax }) => {
 
             <EuiSpacer />
             <Diff
+                css={diffStyle}
                 viewType={showSplit ? 'split' : 'unified'}
                 diffType={type}
                 hunks={hunks || EMPTY_HUNKS}

--- a/packages/orchestrator-ui-components/src/components/WfoDiff/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoDiff/styles.ts
@@ -1,0 +1,46 @@
+import { shade, tint } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+import { WfoTheme } from '@/hooks';
+
+export const getWfoDiffStyles = ({
+    theme,
+    toSecondaryColor,
+    isDarkThemeActive,
+}: WfoTheme) => {
+    const SHADE_FACTOR = 0.5;
+    const TINT_FACTOR = 0.65;
+
+    const insertGutterColor = toSecondaryColor(theme.colors.success);
+    const insertCodeColor = isDarkThemeActive
+        ? shade(insertGutterColor, SHADE_FACTOR)
+        : tint(insertGutterColor, TINT_FACTOR);
+
+    const deleteColor = toSecondaryColor(theme.colors.danger);
+    const deleteSecondaryColor = isDarkThemeActive
+        ? shade(deleteColor, SHADE_FACTOR)
+        : tint(deleteColor, TINT_FACTOR);
+
+    const diffStyle = css({
+        '.diff-code-insert': {
+            backgroundColor: insertCodeColor,
+        },
+        '.diff-gutter-insert': {
+            backgroundColor: insertGutterColor,
+        },
+        '.diff-code-delete': {
+            backgroundColor: deleteSecondaryColor,
+        },
+        '.diff-gutter-delete': {
+            backgroundColor: deleteColor,
+        },
+
+        '.operator, .punctuation': {
+            color: theme.colors.text,
+        },
+    });
+
+    return {
+        diffStyle,
+    };
+};

--- a/packages/orchestrator-ui-components/src/components/WfoSettings/WfoFlushSettings.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSettings/WfoFlushSettings.tsx
@@ -70,12 +70,7 @@ export const WfoFlushSettings: FunctionComponent = () => {
     };
 
     return (
-        <EuiPanel
-            hasShadow={false}
-            color="subdued"
-            paddingSize="l"
-            style={{ width: '50%' }}
-        >
+        <EuiPanel hasShadow={false} color="subdued" paddingSize="l">
             <EuiText size="s">
                 <h4>{t('flushCacheSettingsTitle')}</h4>
             </EuiText>

--- a/packages/orchestrator-ui-components/src/components/WfoSettings/WfoFlushSettings.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSettings/WfoFlushSettings.tsx
@@ -11,11 +11,21 @@ import {
 } from '@elastic/eui';
 import { EuiComboBoxOptionOption } from '@elastic/eui/src/components/combo_box/types';
 
-import { useCacheNames, useShowToastMessage } from '@/hooks';
+import {
+    useCacheNames,
+    useShowToastMessage,
+    useWithOrchestratorTheme,
+} from '@/hooks';
 import { useClearCacheMutation } from '@/rtk';
 import { ToastTypes } from '@/types';
 
+import { getWfoFlushSettingsStyle } from './styles';
+
 export const WfoFlushSettings: FunctionComponent = () => {
+    const { comboboxStyle } = useWithOrchestratorTheme(
+        getWfoFlushSettingsStyle,
+    );
+
     const [clearCache] = useClearCacheMutation();
 
     const t = useTranslations('settings.page');
@@ -71,6 +81,7 @@ export const WfoFlushSettings: FunctionComponent = () => {
             </EuiText>
             <EuiSpacer size="m" />
             <EuiComboBox
+                css={comboboxStyle}
                 aria-label="Flush settings"
                 placeholder={t('selectSettings')}
                 singleSelection={{ asPlainText: true }}

--- a/packages/orchestrator-ui-components/src/components/WfoSettings/WfoModifySettings.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSettings/WfoModifySettings.tsx
@@ -11,12 +11,7 @@ export const WfoModifySettings = () => {
     const t = useTranslations('settings.page');
     return (
         <EuiFlexItem>
-            <EuiPanel
-                hasShadow={false}
-                color="subdued"
-                paddingSize="l"
-                css={{ width: '50%' }}
-            >
+            <EuiPanel hasShadow={false} color="subdued" paddingSize="l">
                 <EuiText size="s">
                     <h4>{t('resetTextSearchIndex')}</h4>
                 </EuiText>
@@ -24,12 +19,7 @@ export const WfoModifySettings = () => {
                 <WfoResetTextSearchIndexButton />
             </EuiPanel>
             <EuiSpacer />
-            <EuiPanel
-                hasShadow={false}
-                color="subdued"
-                paddingSize="l"
-                css={{ width: '50%' }}
-            >
+            <EuiPanel hasShadow={false} color="subdued" paddingSize="l">
                 <EuiText size="s">
                     <h4>{t('modifyEngine')}</h4>
                 </EuiText>

--- a/packages/orchestrator-ui-components/src/components/WfoSettings/WfoStatus.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSettings/WfoStatus.tsx
@@ -23,12 +23,7 @@ export const WfoStatus = () => {
     const t = useTranslations('settings.page');
 
     return (
-        <EuiPanel
-            hasShadow={false}
-            color="subdued"
-            paddingSize="l"
-            style={{ width: '50%' }}
-        >
+        <EuiPanel hasShadow={false} color="subdued" paddingSize="l">
             <EuiFlexGroup>
                 <EuiFlexItem grow={false} style={{ minWidth: 208 }}>
                     <EuiText size="s">

--- a/packages/orchestrator-ui-components/src/components/WfoSettings/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSettings/styles.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+
+import { WfoTheme } from '@/hooks';
+
+export const getWfoFlushSettingsStyle = (wfoTheme: WfoTheme) => {
+    const { theme } = wfoTheme;
+    const comboboxStyle = css({
+        // .euiComboBox is needed to override eui styling (more specific)
+        '&.euiComboBox': {
+            '.euiComboBox__inputWrap': {
+                border: `1px solid ${theme.colors.lightShade}`,
+                boxShadow: 'none',
+                backgroundColor: theme.colors.body,
+            },
+            '&.euiComboBox-isOpen': {
+                '.euiComboBox__inputWrap': {
+                    backgroundColor: theme.colors.emptyShade,
+                },
+            },
+        },
+    });
+
+    return {
+        comboboxStyle,
+    };
+};

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/styles.ts
@@ -2,11 +2,11 @@ import { css } from '@emotion/react';
 
 import { WfoTheme } from '@/hooks';
 
-export const getStyles = ({ theme }: WfoTheme) => {
+export const getStyles = ({ theme, toSecondaryColor }: WfoTheme) => {
     const iconStyle = css({
         width: 45,
         height: 45,
-        backgroundColor: 'rgb(193,221,241,1)',
+        backgroundColor: toSecondaryColor(theme.colors.primary),
         paddingTop: 13,
         paddingLeft: 15,
         borderRadius: 7,

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/styles.ts
@@ -6,6 +6,7 @@ export const getStyles = ({ theme }: WfoTheme) => {
     const contentCellStyle = {
         padding: (theme.base / 4) * 3,
         borderBottom: theme.border.thin,
+        borderBottomColor: theme.colors.lightShade,
     };
 
     const headerCellStyle = css({

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStep.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStep.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
 
 import { WfoJsonCodeBlock } from '@/components';
-import { useWithOrchestratorTheme } from '@/hooks';
+import { useOrchestratorTheme, useWithOrchestratorTheme } from '@/hooks';
 import { WfoChevronDown, WfoChevronUp } from '@/icons';
 import type { EmailState } from '@/types';
 import { StepStatus } from '@/types';
@@ -42,6 +42,7 @@ export const WfoStep = React.forwardRef(
     ) => {
         const { isExpanded, step, userInputForm } = stepListItem;
 
+        const { theme } = useOrchestratorTheme();
         const {
             stepEmailContainerStyle,
             getStepHeaderStyle,
@@ -148,8 +149,14 @@ export const WfoStep = React.forwardRef(
                                             hasStepContent,
                                         )}
                                     >
-                                        {(isExpanded && <WfoChevronUp />) || (
-                                            <WfoChevronDown />
+                                        {(isExpanded && (
+                                            <WfoChevronUp
+                                                color={theme.colors.text}
+                                            />
+                                        )) || (
+                                            <WfoChevronDown
+                                                color={theme.colors.text}
+                                            />
                                         )}
                                     </EuiFlexItem>
                                 </>

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepStatusIcon/WfoStepStatusIcon.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepStatusIcon/WfoStepStatusIcon.tsx
@@ -71,15 +71,20 @@ export const WfoStepStatusIcon = ({
     ] = (() => {
         switch (stepStatus) {
             case StepStatus.SUSPEND:
-                return [stepStateSuspendIconStyle, '#8E6A00', true, '#8E6A00'];
+                return [
+                    stepStateSuspendIconStyle,
+                    theme.colors.warningText,
+                    true,
+                    theme.colors.warningText,
+                ];
             case StepStatus.PENDING:
-                return [stepStatePendingIconStyle, '#94A4B8'];
+                return [stepStatePendingIconStyle, theme.colors.darkShade];
             case StepStatus.FAILED:
                 return [
                     stepStateFailedIconStyle,
-                    '#AC0A01',
+                    theme.colors.dangerText,
                     true,
-                    theme.colors.danger,
+                    theme.colors.dangerText,
                 ];
             case StepStatus.SKIPPED:
                 return [
@@ -94,9 +99,9 @@ export const WfoStepStatusIcon = ({
             default:
                 return [
                     stepStateSuccessIconStyle,
-                    theme.colors.link,
+                    theme.colors.primaryText,
                     true,
-                    theme.colors.success,
+                    theme.colors.successText,
                 ];
         }
     })();

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/styles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 
 import { WfoTheme } from '@/hooks';
 
-export const getStyles = ({ theme }: WfoTheme) => {
+export const getStyles = ({ theme, toSecondaryColor }: WfoTheme) => {
     const stepSpacerStyle = css({
         borderLeft: `1px solid ${theme.colors.darkShade}`,
         height: '24px',
@@ -61,21 +61,21 @@ export const getStyles = ({ theme }: WfoTheme) => {
 
     const stepStateSuccessIconStyle = css({
         ...stepStateIcon,
-        backgroundColor: '#CCE3F4',
+        backgroundColor: toSecondaryColor(theme.colors.primary),
     });
 
     const stepStateSuspendIconStyle = css({
         ...stepStateIcon,
-        backgroundColor: '#FFF3D0',
+        backgroundColor: toSecondaryColor(theme.colors.warning),
     });
 
     const stepStatePendingIconStyle = css({
         ...stepStateIcon,
-        backgroundColor: '#DCE4EF',
+        backgroundColor: toSecondaryColor(theme.colors.darkShade),
     });
     const stepStateFailedIconStyle = css({
         ...stepStateIcon,
-        backgroundColor: '#F2D4D2',
+        backgroundColor: toSecondaryColor(theme.colors.danger),
     });
 
     const stepHeaderRightStyle = css({

--- a/packages/orchestrator-ui-components/src/pages/settings/WfoSettingsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/settings/WfoSettingsPage.tsx
@@ -3,19 +3,24 @@ import React from 'react';
 import { EuiHorizontalRule, EuiPageHeader, EuiSpacer } from '@elastic/eui';
 
 import { WfoFlushSettings, WfoModifySettings, WfoStatus } from '@/components';
+import { useOrchestratorTheme } from '@/hooks';
 
 export const WfoSettingsPage = () => {
+    const { theme } = useOrchestratorTheme();
+
     return (
         <>
             <EuiSpacer />
 
             <EuiPageHeader pageTitle="Settings" />
             <EuiHorizontalRule />
-            <WfoFlushSettings />
-            <EuiSpacer />
-            <WfoModifySettings />
-            <EuiSpacer />
-            <WfoStatus />
+            <div css={{ maxWidth: theme.base * 40 }}>
+                <WfoFlushSettings />
+                <EuiSpacer />
+                <WfoModifySettings />
+                <EuiSpacer />
+                <WfoStatus />
+            </div>
         </>
     );
 };


### PR DESCRIPTION
#626 

Small adjustments for dark theme in -detail pages. Forms are not in scope of this PR. That would be the next one

Delta view:
![image](https://github.com/workfloworchestrator/orchestrator-ui-library/assets/20791917/d14fb5c8-97e6-4cab-a0a2-89c31e5e5924)

Settings:
![image](https://github.com/workfloworchestrator/orchestrator-ui-library/assets/20791917/da11861c-08c0-48bd-9135-30077ff797cf)

Icons of product blocks:
![image](https://github.com/workfloworchestrator/orchestrator-ui-library/assets/20791917/2e2bd736-389f-49cf-b2bf-83ac2e7e39e4)

Workflow detail:
![image](https://github.com/workfloworchestrator/orchestrator-ui-library/assets/20791917/47124b46-6bc1-49c8-b2b0-19c829ba26de)
