### PR TITLE
1066 Only allows to clear the value when the field is enabled

### DIFF
--- a/.changeset/silly-candles-poke.md
+++ b/.changeset/silly-candles-poke.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+1066 VlanField: Only allows to clear the value when the field is enabled

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/deprecated/VlanField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/deprecated/VlanField.tsx
@@ -159,8 +159,9 @@ function Vlan({
         if (subscriptionId && isFetched && !portIsTagged && value !== '0') {
             onChange('0');
         } else if (
-            (!subscriptionId && value !== '') ||
-            (subscriptionId && portIsTagged && value === '0')
+            !disabled &&
+            ((!subscriptionId && value !== '') ||
+                (subscriptionId && portIsTagged && value === '0'))
         ) {
             onChange('');
         }


### PR DESCRIPTION
#1066 

The Vlan field is depending on the subscription dropdown. When going to the second page, the choices from the first page should be shown in a "disabled" version of the field to remind the user what subscription and vlan were entered on the previous page. The disabled fields on the second page are still acting as active fields, they fetching subscriptions and the allowed vlans. Because of this fetching of available subscriptions, the vlan field was cleared.

This PR introduces a quick fix to prevent the vlan-field to clear the value when it is disabled.