### PR TITLE
1108 fetch env vars with warnings

### DIFF
--- a/.changeset/seven-frogs-jam.md
+++ b/.changeset/seven-frogs-jam.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/eslint-config-custom": minor
+---
+
+1108 For the no-console rule allowing warnings too

--- a/.changeset/shy-rocks-help.md
+++ b/.changeset/shy-rocks-help.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": minor
+---
+
+1108 Adds getEnvironmentVariables helper function that retrieves multiple environment variables and logs warnings in case variables do not exist

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -9,7 +9,7 @@ module.exports = {
         '@next/next/no-html-link-for-pages': 'off',
         '@typescript-eslint/ban-ts-comment': 'warn',
         '@typescript-eslint/no-explicit-any': 'error',
-        'no-console': ['error', { allow: ['error'] }],
+        'no-console': ['error', { allow: ['error', 'warn'] }],
         'react/react-in-jsx-scope': 2,
         'react/jsx-uses-react': 2,
     },

--- a/packages/orchestrator-ui-components/src/contexts/OrchestratorConfigContext.tsx
+++ b/packages/orchestrator-ui-components/src/contexts/OrchestratorConfigContext.tsx
@@ -4,7 +4,7 @@ import { FC, ReactNode, createContext } from 'react';
 import { useOrchestratorConfig } from '@/hooks/useOrchestratorConfig';
 import type { OrchestratorConfig } from '@/types';
 
-export const OrchestratorConfigContext = createContext<OrchestratorConfig>({
+export const emptyOrchestratorConfig: OrchestratorConfig = {
     environmentName: '',
     graphqlEndpointCore: '',
     orchestratorApiBaseUrl: '',
@@ -14,10 +14,14 @@ export const OrchestratorConfigContext = createContext<OrchestratorConfig>({
     useThemeToggle: false,
     showWorkflowInformationLink: false,
     workflowInformationLinkUrl: '',
-});
+};
+
+export const OrchestratorConfigContext = createContext<OrchestratorConfig>(
+    emptyOrchestratorConfig,
+);
 
 export type OrchestratorConfigProviderProps = {
-    initialOrchestratorConfig: OrchestratorConfig;
+    initialOrchestratorConfig: OrchestratorConfig | null;
     children: ReactNode;
 };
 
@@ -25,7 +29,7 @@ export const OrchestratorConfigProvider: FC<
     OrchestratorConfigProviderProps
 > = ({ initialOrchestratorConfig, children }) => {
     const { orchestratorConfig } = useOrchestratorConfig(
-        initialOrchestratorConfig,
+        initialOrchestratorConfig ?? emptyOrchestratorConfig,
     );
 
     return (

--- a/packages/orchestrator-ui-components/src/rtk/storeProvider.tsx
+++ b/packages/orchestrator-ui-components/src/rtk/storeProvider.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import type { ReactNode } from 'react';
 import { Provider } from 'react-redux';
 
+import { emptyOrchestratorConfig } from '@/contexts';
 import { CustomApiConfig } from '@/rtk/slices/customApis';
 import { OrchestratorComponentOverride } from '@/rtk/slices/orchestratorComponentOverride';
 import type { OrchestratorConfig } from '@/types';
@@ -9,7 +10,7 @@ import type { OrchestratorConfig } from '@/types';
 import { getOrchestratorStore } from './store';
 
 export type StoreProviderProps = {
-    initialOrchestratorConfig: OrchestratorConfig;
+    initialOrchestratorConfig: OrchestratorConfig | null;
     orchestratorComponentOverride?: OrchestratorComponentOverride;
     customApis?: CustomApiConfig[];
     children: ReactNode;
@@ -22,7 +23,8 @@ export const StoreProvider = ({
     children,
 }: StoreProviderProps) => {
     const store = getOrchestratorStore({
-        orchestratorConfig: initialOrchestratorConfig,
+        orchestratorConfig:
+            initialOrchestratorConfig ?? emptyOrchestratorConfig,
         orchestratorComponentOverride,
         customApis,
     });

--- a/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.spec.ts
@@ -20,7 +20,7 @@ describe('getEnvironmentVariables()', () => {
         process.env = originalEnv;
     });
 
-    it('returns an empty string as value in the result when the environment variable is not set', () => {
+    it('returns an object with the environment variables and its values', () => {
         process.env.test01 = 'value01';
         process.env.test02 = 'value02';
 
@@ -33,7 +33,7 @@ describe('getEnvironmentVariables()', () => {
         });
     });
 
-    it('returns an object with the environment variables and its values', () => {
+    it('returns an empty string as value in the result when the environment variable is not set', () => {
         process.env.test01 = 'value01';
         process.env.test03 = 'value03';
 

--- a/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.spec.ts
@@ -1,0 +1,51 @@
+import process from 'process';
+
+import { getEnvironmentVariables } from './getEnvironmentVariables';
+
+const originalEnv = process.env;
+
+describe('getEnvironmentVariables()', () => {
+    const warnMock = jest.spyOn(console, 'warn');
+
+    jest.mock('process');
+
+    beforeEach(() => {
+        process.env = {
+            ...originalEnv,
+        };
+        jest.resetAllMocks();
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    it('returns an empty string as value in the result when the environment variable is not set', () => {
+        process.env.test01 = 'value01';
+        process.env.test02 = 'value02';
+
+        const result = getEnvironmentVariables(['test01', 'test02']);
+
+        expect(warnMock).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            test01: 'value01',
+            test02: 'value02',
+        });
+    });
+
+    it('returns an object with the environment variables and its values', () => {
+        process.env.test01 = 'value01';
+        process.env.test03 = 'value03';
+
+        const result = getEnvironmentVariables(['test01', 'test02', 'test03']);
+
+        expect(warnMock).toHaveBeenCalledWith(
+            'Warning: Missing required environment variables: test02',
+        );
+        expect(result).toEqual({
+            test01: 'value01',
+            test02: '',
+            test03: 'value03',
+        });
+    });
+});

--- a/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.ts
+++ b/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.ts
@@ -1,7 +1,7 @@
 import process from 'process';
 
 // By convention, only this function should be used to access the process.env object.
-// It trows an error if any of variables is not set
+// It logs a warning if one or more variables are not set
 export function getEnvironmentVariables<T>(
     envVars: (keyof T)[],
 ): Record<keyof T, string> {

--- a/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.ts
+++ b/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.ts
@@ -1,0 +1,39 @@
+import process from 'process';
+
+// By convention, only this function should be used to access the process.env object.
+// It trows an error if any of variables is not set
+export function getEnvironmentVariables<T>(
+    envVars: (keyof T)[],
+): Record<keyof T, string> {
+    const missingEnvironmentVariables: string[] = [];
+
+    const environmentVariablesWithValues = envVars.reduce(
+        (acc, currentKey) => {
+            const value = process.env[currentKey.toString()];
+
+            if (value === undefined) {
+                missingEnvironmentVariables.push(currentKey.toString());
+            }
+
+            return {
+                ...acc,
+                [currentKey]: value || '',
+            };
+        },
+        {} as Record<keyof T, string>,
+    );
+
+    // Todo: Try preventing to get environment variables in the browser. This code should only run on the Node side.
+    // https://github.com/workfloworchestrator/orchestrator-ui-library/issues/1108
+    if (
+        typeof window === 'undefined' &&
+        missingEnvironmentVariables.length > 0
+    ) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `Warning: Missing required environment variables: ${missingEnvironmentVariables.join(', ')}`,
+        );
+    }
+
+    return environmentVariablesWithValues;
+}

--- a/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.ts
+++ b/packages/orchestrator-ui-components/src/utils/getEnvironmentVariables.ts
@@ -23,13 +23,7 @@ export function getEnvironmentVariables<T>(
         {} as Record<keyof T, string>,
     );
 
-    // Todo: Try preventing to get environment variables in the browser. This code should only run on the Node side.
-    // https://github.com/workfloworchestrator/orchestrator-ui-library/issues/1108
-    if (
-        typeof window === 'undefined' &&
-        missingEnvironmentVariables.length > 0
-    ) {
-        // eslint-disable-next-line no-console
+    if (missingEnvironmentVariables.length > 0) {
         console.warn(
             `Warning: Missing required environment variables: ${missingEnvironmentVariables.join(', ')}`,
         );

--- a/packages/orchestrator-ui-components/src/utils/index.ts
+++ b/packages/orchestrator-ui-components/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './csvDownload';
 export * from './date';
 export * from './environmentVariables';
+export * from './getEnvironmentVariables';
 export * from './getProductNamesFromProcess';
 export * from './getQueryVariablesForExport';
 export * from './getStatusBadgeColor';


### PR DESCRIPTION
#1108 

- Updates the type of context providers to be possibly `null`. This is more realistic since the value is not available when the code runs in the browser context.
- Adds a helper function to retrieve multiple environment variables. The `getEnvironmentVariables` function aggregates all missing variables and logs a warning in the console if anything is missing.