### PR TITLE
Fix 1239 text in form not visible

### DIFF
--- a/.changeset/fresh-beans-brake.md
+++ b/.changeset/fresh-beans-brake.md
@@ -1,0 +1,5 @@
+---
+"@orchestrator-ui/orchestrator-ui-components": patch
+---
+
+Fix form label not visible in SummaryField and TimestampField

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/SummaryField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/SummaryField.tsx
@@ -19,6 +19,7 @@ import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 import { EuiFlexItem, EuiFormRow, EuiText } from '@elastic/eui';
 
 import { getStyles } from '@/components/WfoForms/formFields/SummaryFieldStyling';
+import { getCommonFormFieldStyles } from '@/components/WfoForms/formFields/commonStyles';
 import { useWithOrchestratorTheme } from '@/hooks';
 
 export type SummaryFieldProps = FieldProps<
@@ -38,6 +39,7 @@ function Summary({
     ...props
 }: SummaryFieldProps) {
     const { summaryFieldStyle } = useWithOrchestratorTheme(getStyles);
+    const { formRowStyle } = useWithOrchestratorTheme(getCommonFormFieldStyles);
 
     if (!data) {
         return null;
@@ -79,7 +81,7 @@ function Summary({
         );
 
     return (
-        <EuiFlexItem css={summaryFieldStyle}>
+        <EuiFlexItem css={[summaryFieldStyle, formRowStyle]}>
             <section {...filterDOMProps(props)}>
                 <EuiFormRow
                     label={label}

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/deprecated/TimestampField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/deprecated/TimestampField.tsx
@@ -19,6 +19,9 @@ import { connectField, filterDOMProps } from 'uniforms';
 
 import { EuiDatePicker, EuiFormRow, EuiText } from '@elastic/eui';
 
+import { getCommonFormFieldStyles } from '@/components/WfoForms/formFields/commonStyles';
+import { useWithOrchestratorTheme } from '@/hooks';
+
 import { FieldProps } from '../types';
 
 export function utcTimestampToLocalMoment(utc_timestamp: number) {
@@ -63,9 +66,12 @@ function Timestamp({
     errorMessage,
     ...props
 }: TimestampFieldProps) {
+    const { formRowStyle } = useWithOrchestratorTheme(getCommonFormFieldStyles);
+
     return (
         <div {...filterDOMProps(props)}>
             <EuiFormRow
+                css={formRowStyle}
                 label={label}
                 labelAppend={<EuiText size="m">{description}</EuiText>}
                 error={showInlineError ? errorMessage : false}


### PR DESCRIPTION
Before:
<img width="1046" alt="343169771-768893a5-e623-4a4c-9b61-cce33b1ad86c" src="https://github.com/user-attachments/assets/54aa7e96-0c16-4071-8571-171aff934be4">


After:
![Screenshot 2024-07-15 at 16 52 36](https://github.com/user-attachments/assets/ec47c6da-6195-4e74-97eb-23ab31a7f629)
