### PR TITLE
1294 Rolling back the recent changes in the list fields

### DIFF
--- a/.changeset/proud-worms-tan.md
+++ b/.changeset/proud-worms-tan.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1294 Rollback style-change in list fields

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListAddField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListAddField.tsx
@@ -67,12 +67,12 @@ function ListAdd({
 
     return (
         <div
+            className="add-item"
             {...filterDOMProps(props)}
             onClick={onAction}
             onKeyDown={onAction}
             role="button"
             tabIndex={0}
-            css={{ display: 'flex', justifyContent: 'flex-end' }}
         >
             <EuiIcon
                 type="plus"

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListDelField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListDelField.tsx
@@ -71,8 +71,8 @@ function ListDel({
     return (
         <div
             {...filterDOMProps(props)}
+            className="del-item"
             id={`${id}.remove`}
-            css={{ marginTop: '10px' }}
             onClick={onAction}
             onKeyDown={onAction}
             role="button"

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListField.tsx
@@ -19,8 +19,12 @@ import { connectField, filterDOMProps, joinName, useField } from 'uniforms';
 
 import { EuiFlexItem, EuiFormRow, EuiText } from '@elastic/eui';
 
+import { getCommonFormFieldStyles } from '@/components/WfoForms/formFields/commonStyles';
+import { useWithOrchestratorTheme } from '@/hooks';
+
 import { ListAddField } from './ListAddField';
 import { ListItemField } from './ListItemField';
+import { listFieldStyling } from './listFieldStyling';
 import { FieldProps } from './types';
 
 declare module 'uniforms' {
@@ -57,20 +61,19 @@ function List({
     errorMessage,
     ...props
 }: ListFieldProps) {
+    const { formRowStyle } = useWithOrchestratorTheme(getCommonFormFieldStyles);
+
     const child = useField(joinName(name, '$'), {}, { absoluteName: true })[0];
     const hasListAsChild = child.fieldType === Array;
 
     return (
-        <EuiFlexItem>
+        <EuiFlexItem css={listFieldStyling}>
             <section
                 {...filterDOMProps(props)}
-                css={{
-                    '.euiFormRow__labelWrapper': {
-                        minHeight: '16px',
-                    },
-                }}
+                className={`list-field${hasListAsChild ? ' outer-list' : ''}`}
             >
                 <EuiFormRow
+                    css={formRowStyle}
                     label={label}
                     labelAppend={<EuiText size="m">{description}</EuiText>}
                     error={showInlineError ? errorMessage : false}
@@ -99,13 +102,13 @@ function List({
                                     : child,
                             ),
                     )}
+                    <ListAddField
+                        initialCount={initialCount}
+                        name="$"
+                        disabled={disabled}
+                        outerList={hasListAsChild}
+                    />
                 </ul>
-                <ListAddField
-                    initialCount={initialCount}
-                    name="$"
-                    disabled={disabled}
-                    outerList={hasListAsChild}
-                />
             </section>
         </EuiFlexItem>
     );

--- a/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListItemField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/formFields/ListItemField.tsx
@@ -30,8 +30,8 @@ function ListItem({
     outerList = false,
 }: ListItemFieldProps) {
     return (
-        <li css={{ display: 'flex', flexGrow: 1 }}>
-            <div css={{ flexGrow: 1 }}>{children}</div>
+        <li>
+            {children}
             <ListDelField name="" outerList={outerList} />
         </li>
     );


### PR DESCRIPTION
#1294 

Partial rollback of https://github.com/workfloworchestrator/orchestrator-ui-library/pull/1279

The style changes are rolled back, the logic introduced in that PR are untouched