### PR TITLE
Fix workflow dropdown not refreshed after subscription is set in sync

### DIFF
--- a/.changeset/gold-geese-divide.md
+++ b/.changeset/gold-geese-divide.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1393 Fix workflow dropdown not refreshed after subscription is set in sync

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionActions.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionActions.ts
@@ -1,6 +1,7 @@
 import { SUBSCRIPTION_ACTIONS_ENDPOINT } from '@/configuration';
 import { BaseQueryTypes, orchestratorApi } from '@/rtk';
-import { SubscriptionActions } from '@/types';
+import { CacheTagType, SubscriptionActions } from '@/types';
+import { getCacheTag } from '@/utils/cacheTag';
 
 const subscriptionActionsApi = orchestratorApi.injectEndpoints({
     endpoints: (build) => ({
@@ -12,6 +13,15 @@ const subscriptionActionsApi = orchestratorApi.injectEndpoints({
                 `${SUBSCRIPTION_ACTIONS_ENDPOINT}/${subscriptionId}`,
             extraOptions: {
                 baseQueryType: BaseQueryTypes.fetch,
+            },
+            providesTags: (result, error, queryArguments) => {
+                if (!error && result) {
+                    return getCacheTag(
+                        CacheTagType.subscriptions,
+                        queryArguments.subscriptionId,
+                    );
+                }
+                return [];
             },
         }),
     }),


### PR DESCRIPTION
![Screenshot 2024-09-12 at 16 31 16](https://github.com/user-attachments/assets/aa78311d-de11-46a8-8b1a-a25be226ff7e)
![Screenshot 2024-09-12 at 16 31 30](https://github.com/user-attachments/assets/e64ec8c3-d704-4799-9539-747d4c6b748d)
