### PR TITLE
1398 serialize objects while exporting data

### DIFF
--- a/.changeset/smooth-lies-tease.md
+++ b/.changeset/smooth-lies-tease.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1398 - Adds a generic way of serializing objects when exporting CSV files

--- a/packages/orchestrator-ui-components/src/utils/index.ts
+++ b/packages/orchestrator-ui-components/src/utils/index.ts
@@ -13,6 +13,7 @@ export * from './onlyUnique';
 export * from './optionalArray';
 export * from './resultFlattener';
 export * from './strings';
+export * from './toObjectWithSerializedValues';
 export * from './toObjectWithSortedKeys';
 export * from './uuid';
 export * from './cacheTag';

--- a/packages/orchestrator-ui-components/src/utils/toObjectWithSerializedValues.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/toObjectWithSerializedValues.spec.ts
@@ -1,0 +1,36 @@
+import { toObjectWithSerializedValues } from '@/utils/toObjectWithSerializedValues';
+
+describe('toObjectWithSerializedValues()', () => {
+    it('should serialize object fields', () => {
+        const input = {
+            testObject: { foo: 'bar' },
+        };
+
+        const result = toObjectWithSerializedValues(input);
+
+        expect(result.testObject).toEqual(`{"foo":"bar"}`);
+    });
+
+    it('should not serialize date fields', () => {
+        const testDate = new Date();
+        const input = {
+            date: testDate,
+        };
+
+        const result = toObjectWithSerializedValues(input);
+
+        expect(result.date).toEqual(testDate);
+    });
+
+    it('should not serialize non-date and non-object fields', () => {
+        const input = {
+            string: 'string',
+            number: 1,
+            boolean: true,
+        };
+
+        const result = toObjectWithSerializedValues(input);
+
+        expect(result).toEqual(input);
+    });
+});

--- a/packages/orchestrator-ui-components/src/utils/toObjectWithSerializedValues.ts
+++ b/packages/orchestrator-ui-components/src/utils/toObjectWithSerializedValues.ts
@@ -1,0 +1,17 @@
+export const toObjectWithSerializedValues = <T extends object>(
+    inputObject: T,
+) => {
+    const entries = Object.entries(inputObject);
+    const mappedEntries = entries.map(([key, value]) => {
+        if (
+            value !== null &&
+            value.constructor !== Date &&
+            typeof value === 'object'
+        ) {
+            return [key, JSON.stringify(value)];
+        }
+        return [key, value];
+    });
+
+    return Object.fromEntries(mappedEntries);
+};


### PR DESCRIPTION
#1398 

- Implements a generic way of serializing objects when exporting CSV files
- added "date" objects as an exception to not serialize