### PR TITLE
874: Use NEXT_PUBLIC env to disable cache in development mode

### DIFF
--- a/.changeset/loud-apes-refuse.md
+++ b/.changeset/loud-apes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': minor
+---
+
+Adds flags to disable RTK cache in development

--- a/packages/orchestrator-ui-components/src/rtk/api.ts
+++ b/packages/orchestrator-ui-components/src/rtk/api.ts
@@ -143,4 +143,6 @@ export const orchestratorApi = createApi({
         CacheTagType.processStatusCounts,
         CacheTagType.subscriptions,
     ],
+    keepUnusedDataFor:
+        process.env.NEXT_PUBLIC_DISABLE_CACHE === 'true' ? 0 : 60 * 60 * 1000,
 });


### PR DESCRIPTION
I propose a NEXT_PUBLIC_DISABLE_CACHE enviroment variable here instead of adding it to the OrchestratorConfig type because:
- This should only be used in development mode scenarios
- The orchestratorConfig object is not available yet when the RTKQuery api is initialized and we need to set the keepUnusedDataFor property. 