### PR TITLE
1402 table row context menu

### DIFF
--- a/.changeset/popular-apes-shop.md
+++ b/.changeset/popular-apes-shop.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1402 Adds context menu to be used in the table. It exposes a callback that is triggered when the menu opens (for optionally triggering a REST call to populate the menu)

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoRowContextMenu/WfoRowContextMenu.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoRowContextMenu/WfoRowContextMenu.tsx
@@ -1,0 +1,41 @@
+import React, { FC, useState } from 'react';
+
+import {
+    EuiButtonIcon,
+    EuiContextMenu,
+    EuiContextMenuPanelDescriptor,
+    EuiPopover,
+} from '@elastic/eui';
+
+import { WfoDotsHorizontal } from '@/icons/WfoDotsHorizontal';
+
+export const WfoRowContextMenu: FC<{
+    items: Array<EuiContextMenuPanelDescriptor>;
+}> = ({ items }) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const closePopover = () => setIsOpen(false);
+    const togglePopover = () => setIsOpen(!isOpen);
+
+    return (
+        <EuiPopover
+            button={
+                <EuiButtonIcon
+                    iconType={() => <WfoDotsHorizontal />}
+                    onClick={togglePopover}
+                    aria-label="Row context menu"
+                />
+            }
+            isOpen={isOpen}
+            closePopover={closePopover}
+            panelPaddingSize="none"
+            anchorPosition="leftUp"
+        >
+            <EuiContextMenu
+                initialPanelId={0}
+                panels={items}
+                onClick={closePopover}
+            />
+        </EuiPopover>
+    );
+};

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoRowContextMenu/WfoRowContextMenu.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoRowContextMenu/WfoRowContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
 
 import {
     EuiButtonIcon,
@@ -9,10 +9,24 @@ import {
 
 import { WfoDotsHorizontal } from '@/icons/WfoDotsHorizontal';
 
-export const WfoRowContextMenu: FC<{
-    items: Array<EuiContextMenuPanelDescriptor>;
-}> = ({ items }) => {
+export type WfoRowContextMenuProps = {
+    items: EuiContextMenuPanelDescriptor[];
+    onOpenContextMenu?: () => void;
+};
+
+export const WfoRowContextMenu: FC<WfoRowContextMenuProps> = ({
+    items,
+    onOpenContextMenu,
+}) => {
     const [isOpen, setIsOpen] = useState(false);
+
+    const onOpenContextMenuRef = useRef(onOpenContextMenu);
+
+    useEffect(() => {
+        if (isOpen) {
+            onOpenContextMenuRef.current?.();
+        }
+    }, [isOpen, onOpenContextMenuRef]);
 
     const closePopover = () => setIsOpen(false);
     const togglePopover = () => setIsOpen(!isOpen);

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoRowContextMenu/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoRowContextMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './WfoRowContextMenu';

--- a/packages/orchestrator-ui-components/src/components/WfoTable/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/index.ts
@@ -12,6 +12,7 @@ export * from './WfoTableWithFilter';
 export * from './WfoSortButtons';
 export * from './WfoFirstPartUUID';
 export * from './WfoInlineJson';
+export * from './WfoRowContextMenu';
 
 export * from './WfoAdvancedTable';
 export * from './WfoTable';

--- a/packages/orchestrator-ui-components/src/icons/WfoDotsHorizontal.tsx
+++ b/packages/orchestrator-ui-components/src/icons/WfoDotsHorizontal.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react';
+
+import { WfoIconProps } from '@/icons/WfoIconProps';
+
+export const WfoDotsHorizontal: FC<WfoIconProps> = ({
+    width = 20,
+    height = 20,
+    color = 'currentColor',
+}) => (
+    <svg
+        width={width}
+        height={height}
+        viewBox="0 0 24 24"
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <title>icon/dots-horizontal</title>
+        <g
+            id="Symbols"
+            stroke="none"
+            strokeWidth="1"
+            fill="none"
+            fillRule="evenodd"
+        >
+            <g id="icon/dots-horizontal" fill={color} fillRule="nonzero">
+                <path
+                    d="M8,12 C8,13.1046 7.10457,14 6,14 C4.89543,14 4,13.1046 4,12 C4,10.89543 4.89543,10 6,10 C7.10457,10 8,10.89543 8,12 Z M14,12 C14,13.1046 13.1046,14 12,14 C10.89543,14 10,13.1046 10,12 C10,10.89543 10.89543,10 12,10 C13.1046,10 14,10.89543 14,12 Z M18,14 C19.1046,14 20,13.1046 20,12 C20,10.89543 19.1046,10 18,10 C16.8954,10 16,10.89543 16,12 C16,13.1046 16.8954,14 18,14 Z"
+                    id="Combined-Shape"
+                ></path>
+            </g>
+        </g>
+    </svg>
+);

--- a/packages/orchestrator-ui-components/src/icons/heroicons/WfoHeroIconsWrapper.tsx
+++ b/packages/orchestrator-ui-components/src/icons/heroicons/WfoHeroIconsWrapper.tsx
@@ -22,6 +22,7 @@ export const WfoHeroIconsWrapper: FC<WfoHeroIconsWrapperProps> = ({
                 marginRight: theme.size.xs,
                 display: 'flex',
                 alignItems: 'center',
+                height: '100%',
             }}
         >
             {children}

--- a/packages/orchestrator-ui-components/src/icons/heroicons/WfoWrench.tsx
+++ b/packages/orchestrator-ui-components/src/icons/heroicons/WfoWrench.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react';
 
-import { WfoIconProps, withWfoHeroIconsWrapper } from '@/icons';
+import { WfoIconProps } from '@/icons';
+
+import { withWfoHeroIconsWrapper } from './WfoHeroIconsWrapper';
 
 const WfoWrenchSvg: FC<WfoIconProps> = ({
     width = 20,

--- a/packages/orchestrator-ui-components/src/icons/heroicons/WfoWrench.tsx
+++ b/packages/orchestrator-ui-components/src/icons/heroicons/WfoWrench.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+
+import { WfoIconProps, withWfoHeroIconsWrapper } from '@/icons';
+
+const WfoWrenchSvg: FC<WfoIconProps> = ({
+    width = 20,
+    height = 20,
+    color = 'currentColor',
+}) => (
+    <svg
+        width={width}
+        height={height}
+        viewBox="0 0 24 24"
+        fill={color}
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            fillRule="evenodd"
+            d="M12 6.75a5.25 5.25 0 0 1 6.775-5.025.75.75 0 0 1 .313 1.248l-3.32 3.319c.063.475.276.934.641 1.299.365.365.824.578 1.3.64l3.318-3.319a.75.75 0 0 1 1.248.313 5.25 5.25 0 0 1-5.472 6.756c-1.018-.086-1.87.1-2.309.634L7.344 21.3A3.298 3.298 0 1 1 2.7 16.657l8.684-7.151c.533-.44.72-1.291.634-2.309A5.342 5.342 0 0 1 12 6.75ZM4.117 19.125a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75h-.008a.75.75 0 0 1-.75-.75v-.008Z"
+            clipRule="evenodd"
+        />
+    </svg>
+);
+
+export const WfoWrench = withWfoHeroIconsWrapper(WfoWrenchSvg);

--- a/packages/orchestrator-ui-components/src/icons/heroicons/index.ts
+++ b/packages/orchestrator-ui-components/src/icons/heroicons/index.ts
@@ -1,2 +1,4 @@
-export * from './WfoArrowsUpDown';
 export * from './WfoHeroIconsWrapper';
+
+export * from './WfoArrowsUpDown';
+export * from './WfoWrench';

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/index.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/index.ts
@@ -10,6 +10,7 @@ export * from './relatedSubscriptions';
 export * from './settings';
 export * from './startOptions';
 export * from './streamMessages';
+export * from './subscriptionActions';
 export * from './subscriptionDetail';
 export * from './subscriptionInUseByRelationsList';
 export * from './subscriptionList';

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionActions.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionActions.ts
@@ -27,4 +27,7 @@ const subscriptionActionsApi = orchestratorApi.injectEndpoints({
     }),
 });
 
-export const { useGetSubscriptionActionsQuery } = subscriptionActionsApi;
+export const {
+    useGetSubscriptionActionsQuery,
+    useLazyGetSubscriptionActionsQuery,
+} = subscriptionActionsApi;


### PR DESCRIPTION
#1402 

Adds context menu to be used in the table. It exposes a callback that is triggered when the menu opens (for optionally triggering a REST call to populate the menu)

Example usage:
![image](https://github.com/user-attachments/assets/8d13a536-9ae1-4c2c-9d28-2fc39fe5e81e)
