### PR TITLE
1561 Fixes double copy icon in subscription detail page at the in-use-by-subscriptions section

### DIFF
--- a/.changeset/silent-plums-invite.md
+++ b/.changeset/silent-plums-invite.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1561 Fixes double copy icon in subscription detail page at the in-use-by-subscriptions section

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoInUseByRelations.tsx
@@ -52,6 +52,7 @@ export const WfoInUseByRelations = ({
                 value: (
                     <WfoFirstPartUUID
                         UUID={inUseByRelationDetails.subscriptionId}
+                        showCopyIcon={false}
                     />
                 ),
                 textToCopy: inUseByRelationDetails.subscriptionId,

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoFirstPartUUID/WfoFirstPartUUID.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoFirstPartUUID/WfoFirstPartUUID.tsx
@@ -10,30 +10,36 @@ import { COPY_ICON_CLASS, getStyles } from './styles';
 
 export type WfoFirstUUIDPartProps = {
     UUID: string;
+    showCopyIcon?: boolean;
 };
 
-export const WfoFirstPartUUID: FC<WfoFirstUUIDPartProps> = ({ UUID }) => {
+export const WfoFirstPartUUID: FC<WfoFirstUUIDPartProps> = ({
+    UUID,
+    showCopyIcon = true,
+}) => {
     const { uuidFieldStyle, clickable } = useWithOrchestratorTheme(getStyles);
     const { theme } = useOrchestratorTheme();
 
     return (
         <span css={uuidFieldStyle}>
             {getFirstUuidPart(UUID)}
-            <EuiCopy textToCopy={UUID}>
-                {(copy) => (
-                    <div
-                        className={COPY_ICON_CLASS}
-                        onClick={copy}
-                        css={clickable}
-                    >
-                        <WfoClipboardCopy
-                            width={16}
-                            height={16}
-                            color={theme.colors.mediumShade}
-                        />
-                    </div>
-                )}
-            </EuiCopy>
+            {showCopyIcon && (
+                <EuiCopy textToCopy={UUID}>
+                    {(copy) => (
+                        <div
+                            className={COPY_ICON_CLASS}
+                            onClick={copy}
+                            css={clickable}
+                        >
+                            <WfoClipboardCopy
+                                width={16}
+                                height={16}
+                                color={theme.colors.mediumShade}
+                            />
+                        </div>
+                    )}
+                </EuiCopy>
+            )}
         </span>
     );
 };


### PR DESCRIPTION
#1561 

Fixes double copy icon in subscription detail page at the in-use-by-subscriptions section