### PR TITLE
Fix type expected by uuid function

### DIFF
--- a/.changeset/clean-bags-visit.md
+++ b/.changeset/clean-bags-visit.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+Fixes calling getFirstUuidPart with null value

--- a/packages/orchestrator-ui-components/src/utils/uuid.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/uuid.spec.ts
@@ -5,6 +5,11 @@ describe('getFirstUuidPart()', () => {
         const result = getFirstUuidPart('12345678-1234-1234-1234-123456789abc');
         expect(result).toEqual('12345678');
     });
+
+    it('returns empty string for empty uuid', () => {
+        const result = getFirstUuidPart();
+        expect(result).toEqual('');
+    });
 });
 
 describe('isUuid4()', () => {

--- a/packages/orchestrator-ui-components/src/utils/uuid.ts
+++ b/packages/orchestrator-ui-components/src/utils/uuid.ts
@@ -1,4 +1,5 @@
-export const getFirstUuidPart = (uuid: string): string => uuid.slice(0, 8);
+export const getFirstUuidPart = (uuid?: string): string =>
+    uuid ? uuid.slice(0, 8) : '';
 
 export const isUuid4 = (value: string): boolean =>
     !!value.match(


### PR DESCRIPTION
This fixes the bug where an NMS chassis detail page in de Surf implementation of the app raises an unexpected error and causes the page to crash. The error is caused by because a result for retrieving the ports has a subscriptionId that is Null. 

