### PR TITLE
289 clickable badges on metadata page

### DIFF
--- a/.changeset/swift-jars-exercise.md
+++ b/.changeset/swift-jars-exercise.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+289 Metadata page: making related product blocks, resource types and product tags badges clickable. It will update the search query to show that specific item.

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoProductBlockBadge/WfoProductBlockBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoProductBlockBadge/WfoProductBlockBadge.tsx
@@ -72,13 +72,7 @@ export function WfoProductBlockBadge({
     return (
         <WfoBadge textColor={textColor} color={badgeColor}>
             {link ? (
-                <Link
-                    css={{
-                        color: textColor,
-                        textDecoration: 'none',
-                    }}
-                    href={link}
-                >
+                <Link css={{ color: textColor }} href={link}>
                     {children}
                 </Link>
             ) : (

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoProductBlockBadge/WfoProductBlockBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoProductBlockBadge/WfoProductBlockBadge.tsx
@@ -71,7 +71,19 @@ export function WfoProductBlockBadge({
 
     return (
         <WfoBadge textColor={textColor} color={badgeColor}>
-            {link ? <Link href={link}>{children}</Link> : children}
+            {link ? (
+                <Link
+                    css={{
+                        color: textColor,
+                        textDecoration: 'none',
+                    }}
+                    href={link}
+                >
+                    {children}
+                </Link>
+            ) : (
+                children
+            )}
         </WfoBadge>
     );
 }

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoProductBlockBadge/WfoProductBlockBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoProductBlockBadge/WfoProductBlockBadge.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 
-import { useOrchestratorTheme } from '../../../hooks';
-import { BadgeType } from '../../../types';
+import Link from 'next/link';
+
+import { useOrchestratorTheme } from '@/hooks';
+import { BadgeType } from '@/types';
+
 import { WfoBadge } from '../WfoBadge';
 
 export type WfoProductBlockBadgeProps = {
     children: string;
+    link?: string;
     badgeType: BadgeType;
 };
 
 export function WfoProductBlockBadge({
     children,
+    link,
     badgeType,
 }: WfoProductBlockBadgeProps) {
     const { theme, toSecondaryColor } = useOrchestratorTheme();
@@ -66,7 +71,7 @@ export function WfoProductBlockBadge({
 
     return (
         <WfoBadge textColor={textColor} color={badgeColor}>
-            {children}
+            {link ? <Link href={link}>{children}</Link> : children}
         </WfoBadge>
     );
 }

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductBlocksPage.tsx
@@ -8,6 +8,8 @@ import {
     DEFAULT_PAGE_SIZE,
     DEFAULT_PAGE_SIZES,
     METADATA_PRODUCT_BLOCKS_TABLE_LOCAL_STORAGE_KEY,
+    PATH_METADATA_PRODUCT_BLOCKS,
+    PATH_METADATA_RESOURCE_TYPES,
     StoredTableConfig,
     WfoDataSorting,
     WfoDateTime,
@@ -41,6 +43,7 @@ import {
     csvDownloadHandler,
     getConcatenatedResult,
     getCsvFileNameWithDate,
+    getQueryUrl,
     getQueryVariablesForExport,
     parseDateToLocaleDateTimeString,
     parseIsoString,
@@ -131,12 +134,16 @@ export const WfoProductBlocksPage = () => {
             label: t('dependingProductBlocks'),
             renderData: (dependsOn) => (
                 <>
-                    {dependsOn.map((productBlock, index) => (
+                    {dependsOn.map(({ name }, index) => (
                         <WfoProductBlockBadge
                             key={index}
+                            link={getQueryUrl(
+                                PATH_METADATA_PRODUCT_BLOCKS,
+                                `name:"${name}"`,
+                            )}
                             badgeType={BadgeType.PRODUCT_BLOCK}
                         >
-                            {productBlock.name}
+                            {name}
                         </WfoProductBlockBadge>
                     ))}
                 </>
@@ -153,24 +160,32 @@ export const WfoProductBlocksPage = () => {
             width: '700px',
             renderData: (resourceTypes) => (
                 <>
-                    {resourceTypes.map((resourceType, index) => (
+                    {resourceTypes.map(({ resourceType }, index) => (
                         <WfoProductBlockBadge
                             key={index}
+                            link={getQueryUrl(
+                                PATH_METADATA_RESOURCE_TYPES,
+                                `resourceType:"${resourceType}"`,
+                            )}
                             badgeType={BadgeType.RESOURCE_TYPE}
                         >
-                            {resourceType.resourceType}
+                            {resourceType}
                         </WfoProductBlockBadge>
                     ))}
                 </>
             ),
             renderDetails: (resourceTypes) => (
                 <EuiBadgeGroup gutterSize="s">
-                    {resourceTypes.map((resourceType, index) => (
+                    {resourceTypes.map(({ resourceType }, index) => (
                         <WfoProductBlockBadge
                             key={index}
+                            link={getQueryUrl(
+                                PATH_METADATA_RESOURCE_TYPES,
+                                `resourceType:"${resourceType}"`,
+                            )}
                             badgeType={BadgeType.RESOURCE_TYPE}
                         >
-                            {resourceType.resourceType}
+                            {resourceType}
                         </WfoProductBlockBadge>
                     ))}
                 </EuiBadgeGroup>

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
@@ -164,19 +164,22 @@ export const WfoProductsPage = () => {
             columnType: ColumnType.DATA,
             label: t('productBlocks'),
             width: '250px',
-            renderData: (productBlocks) =>
-                productBlocks.map(({ name }, index) => (
-                    <WfoProductBlockBadge
-                        key={index}
-                        link={getQueryUrl(
-                            PATH_METADATA_PRODUCT_BLOCKS,
-                            `name:"${name}"`,
-                        )}
-                        badgeType={BadgeType.PRODUCT_BLOCK}
-                    >
-                        {name}
-                    </WfoProductBlockBadge>
-                )),
+            renderData: (productBlocks) => (
+                <>
+                    {productBlocks.map(({ name }, index) => (
+                        <WfoProductBlockBadge
+                            key={index}
+                            link={getQueryUrl(
+                                PATH_METADATA_PRODUCT_BLOCKS,
+                                `name:"${name}"`,
+                            )}
+                            badgeType={BadgeType.PRODUCT_BLOCK}
+                        >
+                            {name}
+                        </WfoProductBlockBadge>
+                    ))}
+                </>
+            ),
             renderTooltip: (productBlocks) =>
                 productBlocks.map((productBlock) => (
                     <p key={productBlock.name}>- {productBlock.name}</p>

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import {
+    PATH_METADATA_PRODUCT_BLOCKS,
     WfoDataSorting,
     getPageIndexChangeHandler,
     getPageSizeChangeHandler,
@@ -35,6 +36,7 @@ import type { GraphqlQueryVariables, ProductDefinition } from '@/types';
 import { BadgeType, SortOrder } from '@/types';
 import {
     getConcatenatedResult,
+    getQueryUrl,
     getQueryVariablesForExport,
     parseDateToLocaleDateTimeString,
     parseIsoString,
@@ -162,23 +164,23 @@ export const WfoProductsPage = () => {
             columnType: ColumnType.DATA,
             label: t('productBlocks'),
             width: '250px',
-            renderData: (productBlocks) => (
-                <>
-                    {productBlocks.map((block, index) => (
-                        <WfoProductBlockBadge
-                            key={index}
-                            badgeType={BadgeType.PRODUCT_BLOCK}
-                        >
-                            {block.name}
-                        </WfoProductBlockBadge>
-                    ))}
-                </>
-            ),
-            renderTooltip: (productBlocks) => {
-                return productBlocks.map((productBlock) => (
+            renderData: (productBlocks) =>
+                productBlocks.map(({ name }, index) => (
+                    <WfoProductBlockBadge
+                        key={index}
+                        link={getQueryUrl(
+                            PATH_METADATA_PRODUCT_BLOCKS,
+                            `name:"${name}"`,
+                        )}
+                        badgeType={BadgeType.PRODUCT_BLOCK}
+                    >
+                        {name}
+                    </WfoProductBlockBadge>
+                )),
+            renderTooltip: (productBlocks) =>
+                productBlocks.map((productBlock) => (
                     <p key={productBlock.name}>- {productBlock.name}</p>
-                ));
-            },
+                )),
         },
         createdAt: {
             columnType: ColumnType.DATA,

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
@@ -8,6 +8,7 @@ import {
     DEFAULT_PAGE_SIZE,
     DEFAULT_PAGE_SIZES,
     METADATA_RESOURCE_TYPES_TABLE_LOCAL_STORAGE_KEY,
+    PATH_METADATA_PRODUCT_BLOCKS,
     WfoProductBlockBadge,
     getDataSortHandler,
     getPageIndexChangeHandler,
@@ -37,7 +38,11 @@ import {
     ResourceTypeDefinition,
     SortOrder,
 } from '@/types';
-import { getConcatenatedResult, getQueryVariablesForExport } from '@/utils';
+import {
+    getConcatenatedResult,
+    getQueryUrl,
+    getQueryVariablesForExport,
+} from '@/utils';
 import {
     csvDownloadHandler,
     getCsvFileNameWithDate,
@@ -114,24 +119,32 @@ export const WfoResourceTypesPage = () => {
             width: '1000px',
             renderData: (productBlocks) => (
                 <>
-                    {productBlocks.map((productBlock, index) => (
+                    {productBlocks.map(({ name }, index) => (
                         <WfoProductBlockBadge
                             key={index}
+                            link={getQueryUrl(
+                                PATH_METADATA_PRODUCT_BLOCKS,
+                                `name:"${name}"`,
+                            )}
                             badgeType={BadgeType.PRODUCT_BLOCK}
                         >
-                            {productBlock.name}
+                            {name}
                         </WfoProductBlockBadge>
                     ))}
                 </>
             ),
             renderDetails: (productBlocks) => (
                 <EuiBadgeGroup gutterSize="s">
-                    {productBlocks.map((productBlock, index) => (
+                    {productBlocks.map(({ name }, index) => (
                         <WfoProductBlockBadge
                             key={index}
+                            link={getQueryUrl(
+                                PATH_METADATA_PRODUCT_BLOCKS,
+                                `name:"${name}"`,
+                            )}
                             badgeType={BadgeType.PRODUCT_BLOCK}
                         >
-                            {productBlock.name}
+                            {name}
                         </WfoProductBlockBadge>
                     ))}
                 </EuiBadgeGroup>

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoTasksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoTasksPage.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { EuiBadgeGroup } from '@elastic/eui';
 
 import {
+    PATH_METADATA_PRODUCTS,
     WfoWorkflowTargetBadge,
     getPageIndexChangeHandler,
     getPageSizeChangeHandler,
@@ -36,6 +37,7 @@ import { mapRtkErrorToWfoError } from '@/rtk/utils';
 import type { GraphqlQueryVariables, TaskDefinition } from '@/types';
 import { BadgeType, SortOrder } from '@/types';
 import {
+    getQueryUrl,
     getQueryVariablesForExport,
     onlyUnique,
     parseDateToLocaleDateTimeString,
@@ -129,6 +131,10 @@ export const WfoTasksPage = () => {
                         .map((productTag, index) => (
                             <WfoProductBlockBadge
                                 key={index}
+                                link={getQueryUrl(
+                                    PATH_METADATA_PRODUCTS,
+                                    `tag:"${productTag}"`,
+                                )}
                                 badgeType={BadgeType.PRODUCT_TAG}
                             >
                                 {productTag}
@@ -143,6 +149,10 @@ export const WfoTasksPage = () => {
                         .map((productTag, index) => (
                             <WfoProductBlockBadge
                                 key={index}
+                                link={getQueryUrl(
+                                    PATH_METADATA_PRODUCTS,
+                                    `tag:"${productTag}"`,
+                                )}
                                 badgeType={BadgeType.PRODUCT_TAG}
                             >
                                 {productTag}

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoWorkflowsPage.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { EuiBadgeGroup } from '@elastic/eui';
 
 import {
+    PATH_METADATA_PRODUCTS,
     WfoDataSorting,
     getPageIndexChangeHandler,
     getPageSizeChangeHandler,
@@ -42,6 +43,7 @@ import type { GraphqlQueryVariables, WorkflowDefinition } from '@/types';
 import { BadgeType, SortOrder } from '@/types';
 import {
     getConcatenatedResult,
+    getQueryUrl,
     getQueryVariablesForExport,
     onlyUnique,
     parseDateToLocaleDateTimeString,
@@ -135,6 +137,10 @@ export const WfoWorkflowsPage = () => {
                         .map((productTag, index) => (
                             <WfoProductBlockBadge
                                 key={index}
+                                link={getQueryUrl(
+                                    PATH_METADATA_PRODUCTS,
+                                    `tag:"${productTag}"`,
+                                )}
                                 badgeType={BadgeType.PRODUCT_TAG}
                             >
                                 {productTag}
@@ -149,6 +155,10 @@ export const WfoWorkflowsPage = () => {
                         .map((productTag, index) => (
                             <WfoProductBlockBadge
                                 key={index}
+                                link={getQueryUrl(
+                                    PATH_METADATA_PRODUCTS,
+                                    `tag:"${productTag}"`,
+                                )}
                                 badgeType={BadgeType.PRODUCT_TAG}
                             >
                                 {productTag}

--- a/packages/orchestrator-ui-components/src/utils/getQueryUrl.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/getQueryUrl.spec.ts
@@ -1,0 +1,9 @@
+import { getQueryUrl } from './getQueryUrl';
+
+describe('getQueryUrl', () => {
+    it('returns a url with the specified query', () => {
+        const result = getQueryUrl('/sample-page/sub-page', 'testQuery');
+
+        expect(result).toEqual('/sample-page/sub-page?queryString=testQuery');
+    });
+});

--- a/packages/orchestrator-ui-components/src/utils/getQueryUrl.ts
+++ b/packages/orchestrator-ui-components/src/utils/getQueryUrl.ts
@@ -1,3 +1,8 @@
+import { DataDisplayParams } from '@/hooks';
+
 export const getQueryUrl = (pageUrl: string, queryString: string) => {
-    return `${pageUrl}?queryString=${queryString}`;
+    // Prevents silently breaking functionality when the DataDisplayParams type changes
+    const queryKey: keyof DataDisplayParams<object> = 'queryString';
+
+    return `${pageUrl}?${queryKey}=${queryString}`;
 };

--- a/packages/orchestrator-ui-components/src/utils/getQueryUrl.ts
+++ b/packages/orchestrator-ui-components/src/utils/getQueryUrl.ts
@@ -1,0 +1,3 @@
+export const getQueryUrl = (pageUrl: string, queryString: string) => {
+    return `${pageUrl}?queryString=${queryString}`;
+};

--- a/packages/orchestrator-ui-components/src/utils/index.ts
+++ b/packages/orchestrator-ui-components/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './filterData';
 export * from './getDefaultTableConfig';
 export * from './getEnvironmentVariables';
 export * from './getObjectKeys';
+export * from './getQueryUrl';
 export * from './getProductNamesFromProcess';
 export * from './getQueryVariablesForExport';
 export * from './getStatusBadgeColor';


### PR DESCRIPTION
#289 

- Metadata page: making related product blocks, resource types and product tags badges clickable. It will update the search query to show that specific item.
- Adds helper util to construct the URL