### PR TITLE
1479 grouped table and csv download updates

### DIFF
--- a/.changeset/real-planets-bake.md
+++ b/.changeset/real-planets-bake.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1479 GroupedTable: The table has a small header with a button "Collapse / Expand", this can now be overridden. csvDownload: the function "csvDownloadHandler" is async and allows to fetch data for the consumer before a CSV download is started by the browser. The newly added "csvDownloadHandlerSync" is introduced if the requested data is already present. Introduced a utility type to help ensuring that all the props of an object will be of type "string". Typically useful for the csvDownload functionality

--- a/.changeset/real-planets-bake.md
+++ b/.changeset/real-planets-bake.md
@@ -1,5 +1,5 @@
 ---
-'@orchestrator-ui/orchestrator-ui-components': patch
+'@orchestrator-ui/orchestrator-ui-components': major
 ---
 
-1479 GroupedTable: The table has a small header with a button "Collapse / Expand", this can now be overridden. csvDownload: Changed the parameters of initiateCsvFileDownload for directly exporting data to CSV. Introduced a utility type to help ensuring that all the props of an object will be of type "string". Typically useful for the csvDownload functionality
+1479 csvDownload (Breaking change): Changed the parameters of initiateCsvFileDownload for directly exporting data to CSV. GroupedTable: The table has a small header with a button "Collapse / Expand", this can now be overridden. Introduced a utility type to help ensuring that all the props of an object will be of type "string". Typically useful for the csvDownload functionality

--- a/.changeset/real-planets-bake.md
+++ b/.changeset/real-planets-bake.md
@@ -2,4 +2,20 @@
 '@orchestrator-ui/orchestrator-ui-components': major
 ---
 
-1479 csvDownload (Breaking change): Changed the parameters of initiateCsvFileDownload for directly exporting data to CSV. GroupedTable: The table has a small header with a button "Collapse / Expand", this can now be overridden. Introduced a utility type to help ensuring that all the props of an object will be of type "string". Typically useful for the csvDownload functionality
+1479:
+- csvDownload (Breaking change): Changed the parameters of initiateCsvFileDownload for directly exporting data to CSV.
+- GroupedTable: The table has a small header with a button "Collapse / Expand", this can now be overridden.
+- Introduced a utility type to help ensuring that all the props of an object will be of type "string". Typically useful for the csvDownload functionality
+
+Changes to be made by the consumer of the library:
+The function `initiateCsvFileDownload` now requires 3 parameters instead of 2. The new parameter is `keyOrder` and is an array of strings representing the desired order of the columns in the CSV file. See example below for the placement.
+
+Before:
+```javascript
+initiateCsvFileDownload(data, fileName);
+```
+
+After:
+```javascript
+initiateCsvFileDownload(data, keyOrder, fileName);
+```

--- a/.changeset/real-planets-bake.md
+++ b/.changeset/real-planets-bake.md
@@ -2,4 +2,4 @@
 '@orchestrator-ui/orchestrator-ui-components': patch
 ---
 
-1479 GroupedTable: The table has a small header with a button "Collapse / Expand", this can now be overridden. csvDownload: the function "csvDownloadHandler" is async and allows to fetch data for the consumer before a CSV download is started by the browser. The newly added "csvDownloadHandlerSync" is introduced if the requested data is already present. Introduced a utility type to help ensuring that all the props of an object will be of type "string". Typically useful for the csvDownload functionality
+1479 GroupedTable: The table has a small header with a button "Collapse / Expand", this can now be overridden. csvDownload: Changed the parameters of initiateCsvFileDownload for directly exporting data to CSV. Introduced a utility type to help ensuring that all the props of an object will be of type "string". Typically useful for the csvDownload functionality

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoTable/WfoGroupedTable/WfoGroupedTable.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoTable/WfoGroupedTable/WfoGroupedTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, ReactElement } from 'react';
 
 import { useTranslations } from 'next-intl';
 
@@ -24,6 +24,7 @@ export type WfoGroupedTableProps<T extends object> = Pick<
 > & {
     data: GroupedData<T>;
     groupNameLabel: string;
+    overrideHeaderSection?: (ExpandButton: ReactElement) => React.ReactNode;
 };
 
 export const WfoGroupedTable = <T extends object>({
@@ -31,6 +32,7 @@ export const WfoGroupedTable = <T extends object>({
     columnConfig,
     groupNameLabel,
     isLoading,
+    overrideHeaderSection,
     className,
 }: WfoGroupedTableProps<T>) => {
     const { headerStyle, rowStyle, cellStyle } =
@@ -53,21 +55,27 @@ export const WfoGroupedTable = <T extends object>({
         columnConfig,
     });
 
+    const ExpandCollapseButton: FC = () => (
+        <EuiButtonEmpty
+            size="xs"
+            onClick={() =>
+                isAllGroupsAndSubgroupsExpanded
+                    ? collapseAllRows()
+                    : expandAllRows()
+            }
+        >
+            {isAllGroupsAndSubgroupsExpanded ? t('collapse') : t('expand')}
+        </EuiButtonEmpty>
+    );
+
     return (
         <>
             <EuiFlexGroup justifyContent="flexEnd">
-                <EuiButtonEmpty
-                    size="xs"
-                    onClick={() =>
-                        isAllGroupsAndSubgroupsExpanded
-                            ? collapseAllRows()
-                            : expandAllRows()
-                    }
-                >
-                    {isAllGroupsAndSubgroupsExpanded
-                        ? t('collapse')
-                        : t('expand')}
-                </EuiButtonEmpty>
+                {overrideHeaderSection ? (
+                    overrideHeaderSection(<ExpandCollapseButton />)
+                ) : (
+                    <ExpandCollapseButton />
+                )}
             </EuiFlexGroup>
 
             <EuiSpacer size="xs" />

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -8,6 +8,10 @@ export type Nullable<T> = T | null;
 
 type GenericResponse = { [key: string]: unknown };
 
+export type StringifyObject<T extends object> = {
+    [key in keyof T]: string;
+};
+
 export type FieldValue = {
     field: string;
     value: string | number | boolean | null;

--- a/packages/orchestrator-ui-components/src/utils/csvDownload.ts
+++ b/packages/orchestrator-ui-components/src/utils/csvDownload.ts
@@ -67,12 +67,12 @@ export const csvDownloadHandler =
         pageInfoMapper: (data: T) => GraphQLPageInfo,
         keyOrder: string[],
         filename: string,
-        addToastFunction?: (
+        addToastFunction: (
             type: ToastTypes,
             text: string,
             title: string,
         ) => void,
-        translationFunction?: (
+        translationFunction: (
             translationKey: string,
             variables?: TranslationValues,
         ) => string,

--- a/packages/orchestrator-ui-components/src/utils/csvDownload.ts
+++ b/packages/orchestrator-ui-components/src/utils/csvDownload.ts
@@ -26,6 +26,12 @@ function startCsvDownload(csvFileContent: string, fileName: string) {
     URL.revokeObjectURL(url);
 }
 
+function totalItemsExceedMaximumItemsForBulkFetching(
+    totalItems?: number | null,
+) {
+    return (totalItems ?? 0) > MAXIMUM_ITEMS_FOR_BULK_FETCHING;
+}
+
 export function initiateCsvFileDownload<T extends object>(
     data: T[],
     fileName: string,
@@ -53,8 +59,8 @@ export const csvDownloadHandlerSync = <T extends object, U extends object>(
     pageInfoMapper: (data: T) => GraphQLPageInfo,
     keyOrder: string[],
     filename: string,
-    addToastFunction: (type: ToastTypes, text: string, title: string) => void,
-    translationFunction: (
+    addToastFunction?: (type: ToastTypes, text: string, title: string) => void,
+    translationFunction?: (
         translationKey: string,
         variables?: TranslationValues,
     ) => string,
@@ -64,7 +70,12 @@ export const csvDownloadHandlerSync = <T extends object, U extends object>(
     );
 
     const pageInfo = pageInfoMapper(data);
-    if ((pageInfo.totalItems ?? 0) > MAXIMUM_ITEMS_FOR_BULK_FETCHING) {
+
+    if (
+        addToastFunction &&
+        translationFunction &&
+        totalItemsExceedMaximumItemsForBulkFetching(pageInfo.totalItems)
+    ) {
         addToastFunction(
             ToastTypes.ERROR,
             translationFunction('notAllResultsExported', {
@@ -84,12 +95,12 @@ export const csvDownloadHandler =
         pageInfoMapper: (data: T) => GraphQLPageInfo,
         keyOrder: string[],
         filename: string,
-        addToastFunction: (
+        addToastFunction?: (
             type: ToastTypes,
             text: string,
             title: string,
         ) => void,
-        translationFunction: (
+        translationFunction?: (
             translationKey: string,
             variables?: TranslationValues,
         ) => string,

--- a/packages/orchestrator-ui-components/src/utils/csvDownload.ts
+++ b/packages/orchestrator-ui-components/src/utils/csvDownload.ts
@@ -87,11 +87,7 @@ export const csvDownloadHandler =
         const data = dataMapper(fetchResult);
         const pageInfo = pageInfoMapper(fetchResult);
 
-        if (
-            addToastFunction &&
-            translationFunction &&
-            totalItemsExceedMaximumItemsForBulkFetching(pageInfo.totalItems)
-        ) {
+        if (totalItemsExceedMaximumItemsForBulkFetching(pageInfo.totalItems)) {
             addToastFunction(
                 ToastTypes.ERROR,
                 translationFunction('notAllResultsExported', {

--- a/packages/orchestrator-ui-components/src/utils/csvDownload.ts
+++ b/packages/orchestrator-ui-components/src/utils/csvDownload.ts
@@ -47,8 +47,8 @@ export const getCsvFileNameWithDate = (fileNameWithoutExtension: string) => {
     return `${fileNameWithoutExtension}_${year}-${month}-${day}-${hour}${minute}${second}.csv`;
 };
 
-export const csvDownloadHandler = <T extends object, U extends object>(
-    dataFetchFunction: () => Promise<T | undefined>,
+export const csvDownloadHandlerSync = <T extends object, U extends object>(
+    data: T,
     dataMapper: (data: T) => U[],
     pageInfoMapper: (data: T) => GraphQLPageInfo,
     keyOrder: string[],
@@ -59,29 +59,67 @@ export const csvDownloadHandler = <T extends object, U extends object>(
         variables?: TranslationValues,
     ) => string,
 ) => {
-    return async () => {
+    const dataForExport = dataMapper(data).map((dataRow) =>
+        toObjectWithSortedKeys(toObjectWithSerializedValues(dataRow), keyOrder),
+    );
+
+    const pageInfo = pageInfoMapper(data);
+    if ((pageInfo.totalItems ?? 0) > MAXIMUM_ITEMS_FOR_BULK_FETCHING) {
+        addToastFunction(
+            ToastTypes.ERROR,
+            translationFunction('notAllResultsExported', {
+                totalResults: pageInfo.totalItems,
+                maximumExportedResults: MAXIMUM_ITEMS_FOR_BULK_FETCHING,
+            }),
+            translationFunction('notAllResultsExportedTitle'),
+        );
+    }
+    initiateCsvFileDownload(dataForExport, filename);
+};
+
+export const csvDownloadHandler =
+    <T extends object, U extends object>(
+        dataFetchFunction: () => Promise<T | undefined>,
+        dataMapper: (data: T) => U[],
+        pageInfoMapper: (data: T) => GraphQLPageInfo,
+        keyOrder: string[],
+        filename: string,
+        addToastFunction: (
+            type: ToastTypes,
+            text: string,
+            title: string,
+        ) => void,
+        translationFunction: (
+            translationKey: string,
+            variables?: TranslationValues,
+        ) => string,
+    ) =>
+    async () => {
         const data: T | undefined = await dataFetchFunction();
 
         if (data) {
-            const dataForExport = dataMapper(data).map((dataRow) =>
-                toObjectWithSortedKeys(
-                    toObjectWithSerializedValues(dataRow),
-                    keyOrder,
-                ),
+            csvDownloadHandlerSync(
+                data,
+                dataMapper,
+                pageInfoMapper,
+                keyOrder,
+                filename,
+                addToastFunction,
+                translationFunction,
             );
-
-            const pageInfo = pageInfoMapper(data);
-            if ((pageInfo.totalItems ?? 0) > MAXIMUM_ITEMS_FOR_BULK_FETCHING) {
-                addToastFunction(
-                    ToastTypes.ERROR,
-                    translationFunction('notAllResultsExported', {
-                        totalResults: pageInfo.totalItems,
-                        maximumExportedResults: MAXIMUM_ITEMS_FOR_BULK_FETCHING,
-                    }),
-                    translationFunction('notAllResultsExportedTitle'),
-                );
-            }
-            initiateCsvFileDownload(dataForExport, filename);
         }
     };
-};
+
+export const getPageInfoForSyncExport = (
+    dataLength: number,
+    sortFields?: string[],
+    filterFields?: string[],
+): GraphQLPageInfo => ({
+    startCursor: 0,
+    endCursor: Math.max(0, dataLength - 1),
+    hasNextPage: false,
+    totalItems: dataLength,
+    hasPreviousPage: false,
+    sortFields: sortFields ?? [],
+    filterFields: filterFields ?? [],
+});


### PR DESCRIPTION
#1479 

Changes to support functionality in the SURF specific app but also useful for consumers of the library:
- GroupedTable: The table has a small header with a button "Collapse / Expand", this can now be overridden
- csvDownload: Changed the parameters of initiateCsvFileDownload for directly exporting data to CSV
- Introduced a utility type to help ensuring that all the props of an object will be of type "string". Typically useful for the csvDownload functionality