### PR TITLE
Remove toast for failed WebSocket that covers the next button

### DIFF
--- a/.changeset/olive-balloons-yawn.md
+++ b/.changeset/olive-balloons-yawn.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1509 Remove toast for failed websocket connection that covers the next and back buttons in the forms.

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/streamMessages.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/streamMessages.ts
@@ -2,11 +2,8 @@ import { debounce } from 'lodash';
 import { getSession } from 'next-auth/react';
 
 import type { WfoSession } from '@/hooks';
-import { addToastMessage } from '@/rtk/slices/toastMessages';
 import type { RootState } from '@/rtk/store';
-import { ToastTypes } from '@/types';
 import { CacheTag, CacheTagType } from '@/types';
-import { getToastMessage } from '@/utils/getToastMessage';
 
 import { orchestratorApi } from '../api';
 
@@ -66,12 +63,6 @@ const streamMessagesApi = orchestratorApi.injectEndpoints({
                 },
             ) {
                 const cleanUp = () => {
-                    const message = getToastMessage(
-                        ToastTypes.ERROR,
-                        'Connection to the server was lost. Please click the websocket icon or refresh the page to reconnect.',
-                        'WebSocket closed',
-                    );
-                    dispatch(addToastMessage(message));
                     clearInterval(pingInterval);
                     updateCachedData(() => false);
                 };


### PR DESCRIPTION
For some users the toast becomes invisible and blocks the Next/Back buttons. Currently cannot reproduce the case where the toast becomes invisible, probably an issue with some browsers.

Discussed with @wouter1975, the current fix is to remove the toast list for failed websockets completely and possibly add the error message in the navbar or somewhere else where could be visible. [#1662](https://github.com/workfloworchestrator/orchestrator-ui-library/issues/1662)

![Screenshot 2025-01-13 at 16 43 50](https://github.com/user-attachments/assets/0eafcf7b-3486-4120-ab9e-367e6cc2a5b1)
![Screenshot 2025-01-13 at 16 43 57](https://github.com/user-attachments/assets/79a0c26f-b979-49e5-968a-ae6cd581fee9)
