### PR TITLE
330 process detail sticky timeline

### DIFF
--- a/.changeset/fuzzy-cherries-doubt.md
+++ b/.changeset/fuzzy-cherries-doubt.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+330 Making timeline in process detail pages sticky to the top of the screen. Introduces a useContentRef hook to refer to the scrollable content div in the pagetemplate

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/ContentContext.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/ContentContext.tsx
@@ -1,0 +1,28 @@
+import React, { FC, ReactNode, createContext } from 'react';
+
+import { getPageTemplateStyles } from '@/components/WfoPageTemplate/WfoPageTemplate/styles';
+import { useWithOrchestratorTheme } from '@/hooks';
+
+export type ContentType = {
+    contentRef: React.RefObject<HTMLDivElement>;
+};
+export const ContentContext = createContext<ContentType | undefined>(undefined);
+export type ContentContextProviderProps = ContentType & {
+    navigationHeight: number;
+    children: ReactNode;
+};
+export const ContentContextProvider: FC<ContentContextProviderProps> = ({
+    contentRef,
+    navigationHeight,
+    children,
+}) => {
+    const { getContentStyle } = useWithOrchestratorTheme(getPageTemplateStyles);
+
+    return (
+        <div ref={contentRef} css={getContentStyle(navigationHeight)}>
+            <ContentContext.Provider value={{ contentRef }}>
+                {children}
+            </ContentContext.Provider>
+        </div>
+    );
+};

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/WfoPageTemplate.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/WfoPageTemplate.tsx
@@ -1,13 +1,13 @@
 import React, { FC, ReactElement, ReactNode, useRef, useState } from 'react';
 
 import type { EuiThemeColorMode } from '@elastic/eui';
-import { EuiPageTemplate } from '@elastic/eui';
-import { EuiSideNavItemType } from '@elastic/eui/src/components/side_nav/side_nav_types';
+import { EuiPageTemplate, EuiSideNavItemType } from '@elastic/eui';
 
 import { WfoBreadcrumbs, WfoPageHeader, WfoSidebar } from '@/components';
-import { ContentContextProvider } from '@/components/WfoPageTemplate/WfoPageTemplate/ContentContext';
-import { getPageTemplateStyles } from '@/components/WfoPageTemplate/WfoPageTemplate/styles';
-import { useOrchestratorTheme, useWithOrchestratorTheme } from '@/hooks';
+import { useWithOrchestratorTheme } from '@/hooks';
+
+import { ContentContextProvider } from './ContentContext';
+import { getPageTemplateStyles } from './styles';
 
 export interface WfoPageTemplateProps {
     getAppLogo: (navigationHeight: number) => ReactElement;
@@ -24,11 +24,11 @@ export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({
     overrideMenuItems,
     onThemeSwitch,
 }) => {
-    const { multiplyByBaseUnit } = useOrchestratorTheme();
-    const { getSidebarStyle } = useWithOrchestratorTheme(getPageTemplateStyles);
+    const { getSidebarStyle, NAVIGATION_HEIGHT } = useWithOrchestratorTheme(
+        getPageTemplateStyles,
+    );
 
     const [isSideMenuVisible, setIsSideMenuVisible] = useState(true);
-    const navigationHeight = multiplyByBaseUnit(3);
 
     const headerRowRef = useRef<HTMLDivElement>(null);
 
@@ -36,7 +36,7 @@ export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({
         <>
             <WfoPageHeader
                 getAppLogo={getAppLogo}
-                navigationHeight={navigationHeight}
+                navigationHeight={NAVIGATION_HEIGHT}
                 onThemeSwitch={onThemeSwitch}
             />
             {/* Sidebar and content area */}
@@ -44,12 +44,12 @@ export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({
                 panelled={false}
                 grow={false}
                 contentBorder={false}
-                minHeight={`calc(100vh - ${navigationHeight}px)`}
+                minHeight={`calc(100vh - ${NAVIGATION_HEIGHT}px)`}
                 restrictWidth={false}
             >
                 {isSideMenuVisible && (
                     <EuiPageTemplate.Sidebar
-                        css={getSidebarStyle(navigationHeight)}
+                        css={getSidebarStyle(NAVIGATION_HEIGHT)}
                     >
                         <WfoSidebar overrideMenuItems={overrideMenuItems} />
                     </EuiPageTemplate.Sidebar>
@@ -57,7 +57,7 @@ export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({
 
                 <ContentContextProvider
                     contentRef={headerRowRef}
-                    navigationHeight={navigationHeight}
+                    navigationHeight={NAVIGATION_HEIGHT}
                 >
                     <EuiPageTemplate.Section>
                         <WfoBreadcrumbs

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/WfoPageTemplate.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/WfoPageTemplate.tsx
@@ -1,18 +1,11 @@
-import React, {
-    FC,
-    ReactElement,
-    ReactNode,
-    createContext,
-    useContext,
-    useRef,
-    useState,
-} from 'react';
+import React, { FC, ReactElement, ReactNode, useRef, useState } from 'react';
 
 import type { EuiThemeColorMode } from '@elastic/eui';
 import { EuiPageTemplate } from '@elastic/eui';
 import { EuiSideNavItemType } from '@elastic/eui/src/components/side_nav/side_nav_types';
 
 import { WfoBreadcrumbs, WfoPageHeader, WfoSidebar } from '@/components';
+import { ContentContextProvider } from '@/components/WfoPageTemplate/WfoPageTemplate/ContentContext';
 import { getPageTemplateStyles } from '@/components/WfoPageTemplate/WfoPageTemplate/styles';
 import { useOrchestratorTheme, useWithOrchestratorTheme } from '@/hooks';
 
@@ -24,35 +17,6 @@ export interface WfoPageTemplateProps {
     onThemeSwitch: (theme: EuiThemeColorMode) => void;
     children: ReactNode;
 }
-
-// Todo move to its own file
-export type ContentType = {
-    contentRef: React.RefObject<HTMLDivElement>;
-};
-export const ContentContext = createContext<ContentType | undefined>(undefined);
-export type ContentContextProviderProps = ContentType & {
-    navigationHeight: number;
-    children: ReactNode;
-};
-export const ContentContextProvider: FC<ContentContextProviderProps> = ({
-    contentRef,
-    navigationHeight,
-    children,
-}) => {
-    const { getContentStyle } = useWithOrchestratorTheme(getPageTemplateStyles);
-
-    return (
-        <div ref={contentRef} css={getContentStyle(navigationHeight)}>
-            <ContentContext.Provider value={{ contentRef }}>
-                {children}
-            </ContentContext.Provider>
-        </div>
-    );
-};
-export const useContentRef = () => ({
-    contentRef: useContext(ContentContext)?.contentRef,
-});
-// ... End of todo
 
 export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({
     children,

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/WfoPageTemplate.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/WfoPageTemplate.tsx
@@ -3,6 +3,7 @@ import React, {
     ReactElement,
     ReactNode,
     createContext,
+    useContext,
     useRef,
     useState,
 } from 'react';
@@ -23,8 +24,6 @@ export interface WfoPageTemplateProps {
     onThemeSwitch: (theme: EuiThemeColorMode) => void;
     children: ReactNode;
 }
-
-// Todo add useContentRef()
 
 // Todo move to its own file
 export type ContentType = {
@@ -50,6 +49,9 @@ export const ContentContextProvider: FC<ContentContextProviderProps> = ({
         </div>
     );
 };
+export const useContentRef = () => ({
+    contentRef: useContext(ContentContext)?.contentRef,
+});
 // ... End of todo
 
 export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/WfoPageTemplate.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/WfoPageTemplate.tsx
@@ -1,4 +1,11 @@
-import React, { FC, ReactElement, ReactNode, useState } from 'react';
+import React, {
+    FC,
+    ReactElement,
+    ReactNode,
+    createContext,
+    useRef,
+    useState,
+} from 'react';
 
 import type { EuiThemeColorMode } from '@elastic/eui';
 import { EuiPageTemplate } from '@elastic/eui';
@@ -16,6 +23,11 @@ export interface WfoPageTemplateProps {
     children: ReactNode;
 }
 
+export type ContentType = {
+    contentRef: React.RefObject<HTMLDivElement>;
+};
+export const ContentContext = createContext<ContentType | undefined>(undefined);
+
 export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({
     children,
     getAppLogo,
@@ -25,6 +37,8 @@ export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({
     const { theme, multiplyByBaseUnit } = useOrchestratorTheme();
     const [isSideMenuVisible, setIsSideMenuVisible] = useState(true);
     const navigationHeight = multiplyByBaseUnit(3);
+
+    const headerRowRef = useRef<HTMLDivElement>(null);
 
     return (
         <>
@@ -52,20 +66,30 @@ export const WfoPageTemplate: FC<WfoPageTemplateProps> = ({
                         <WfoSidebar overrideMenuItems={overrideMenuItems} />
                     </EuiPageTemplate.Sidebar>
                 )}
-                <EuiPageTemplate.Section
+
+                <div
+                    ref={headerRowRef}
                     css={{
                         backgroundColor: theme.colors.emptyShade,
                         overflowY: 'auto',
                         maxHeight: `calc(100vh - ${navigationHeight}px)`,
                     }}
                 >
-                    <WfoBreadcrumbs
-                        handleSideMenuClick={() =>
-                            setIsSideMenuVisible((prevState) => !prevState)
-                        }
-                    />
-                    {children}
-                </EuiPageTemplate.Section>
+                    <ContentContext.Provider
+                        value={{ contentRef: headerRowRef }}
+                    >
+                        <EuiPageTemplate.Section className="test-contnt-area">
+                            <WfoBreadcrumbs
+                                handleSideMenuClick={() =>
+                                    setIsSideMenuVisible(
+                                        (prevState) => !prevState,
+                                    )
+                                }
+                            />
+                            {children}
+                        </EuiPageTemplate.Section>
+                    </ContentContext.Provider>
+                </div>
             </EuiPageTemplate>
         </>
     );

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/index.ts
@@ -1,1 +1,2 @@
+export * from './ContentContext';
 export * from './WfoPageTemplate';

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/styles.ts
@@ -2,7 +2,12 @@ import { css } from '@emotion/react';
 
 import { WfoTheme } from '@/hooks';
 
-export const getPageTemplateStyles = ({ theme }: WfoTheme) => {
+export const getPageTemplateStyles = ({
+    theme,
+    multiplyByBaseUnit,
+}: WfoTheme) => {
+    const NAVIGATION_HEIGHT = multiplyByBaseUnit(3);
+
     const getSidebarStyle = (navigationHeight: number) =>
         css({
             backgroundColor: theme.colors.body,
@@ -18,6 +23,7 @@ export const getPageTemplateStyles = ({ theme }: WfoTheme) => {
         });
 
     return {
+        NAVIGATION_HEIGHT,
         getSidebarStyle,
         getContentStyle,
     };

--- a/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoPageTemplate/WfoPageTemplate/styles.ts
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+
+import { WfoTheme } from '@/hooks';
+
+export const getPageTemplateStyles = ({ theme }: WfoTheme) => {
+    const getSidebarStyle = (navigationHeight: number) =>
+        css({
+            backgroundColor: theme.colors.body,
+            overflowY: 'auto',
+            maxHeight: `calc(100vh - ${navigationHeight}px)`,
+        });
+
+    const getContentStyle = (navigationHeight: number) =>
+        css({
+            backgroundColor: theme.colors.emptyShade,
+            overflowY: 'auto',
+            maxHeight: `calc(100vh - ${navigationHeight}px)`,
+        });
+
+    return {
+        getSidebarStyle,
+        getContentStyle,
+    };
+};

--- a/packages/orchestrator-ui-components/src/components/WfoTimeline/WfoTimeline.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTimeline/WfoTimeline.tsx
@@ -7,7 +7,7 @@ import { useWithOrchestratorTheme } from '@/hooks';
 import { StepStatus } from '@/types';
 
 import { WfoTimelineStep } from './WfoTimelineStep';
-import { getStyles } from './styles';
+import { getTimelineStyles } from './styles';
 import { getTimelinePosition } from './timelineUtils';
 
 export enum TimelinePosition {
@@ -34,7 +34,7 @@ export const WfoTimeline: FC<WfoTimelineProps> = ({
     indexOfCurrentStep = 0,
     onStepClick,
 }) => {
-    const { timelinePanelStyle } = useWithOrchestratorTheme(getStyles);
+    const { timelinePanelStyle } = useWithOrchestratorTheme(getTimelineStyles);
 
     const mapTimelineItemToStep = (
         timelineItem: TimelineItem,
@@ -62,17 +62,7 @@ export const WfoTimeline: FC<WfoTimelineProps> = ({
     };
 
     return (
-        <div
-            css={[
-                timelinePanelStyle,
-                useEuiScrollBar(),
-                {
-                    position: 'sticky',
-                    top: '10px', // todo reusable variable
-                    zIndex: 2, // todo find out why Options button and the process icons got z-index.
-                },
-            ]}
-        >
+        <div css={[timelinePanelStyle, useEuiScrollBar()]}>
             {timelineItems.map(mapTimelineItemToStep)}
         </div>
     );

--- a/packages/orchestrator-ui-components/src/components/WfoTimeline/WfoTimeline.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTimeline/WfoTimeline.tsx
@@ -62,7 +62,17 @@ export const WfoTimeline: FC<WfoTimelineProps> = ({
     };
 
     return (
-        <div css={[timelinePanelStyle, useEuiScrollBar()]}>
+        <div
+            css={[
+                timelinePanelStyle,
+                useEuiScrollBar(),
+                {
+                    position: 'sticky',
+                    top: '10px', // todo reusable variable
+                    zIndex: 2, // todo find out why Options button and the process icons got z-index.
+                },
+            ]}
+        >
             {timelineItems.map(mapTimelineItemToStep)}
         </div>
     );

--- a/packages/orchestrator-ui-components/src/components/WfoTimeline/WfoTimelineStep.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTimeline/WfoTimelineStep.tsx
@@ -6,7 +6,7 @@ import { useWithOrchestratorTheme } from '@/hooks';
 import { StepStatus } from '@/types';
 
 import { TimelinePosition } from './WfoTimeline';
-import { getStyles } from './styles';
+import { getTimelineStyles } from './styles';
 
 export type WfoTimelineStepProps = {
     stepStatus: StepStatus;
@@ -34,7 +34,7 @@ export const WfoTimelineStep = ({
         getStepLineStyle,
         getStepOuterCircleStyle,
         getStepInnerCircleStyle,
-    } = useWithOrchestratorTheme(getStyles);
+    } = useWithOrchestratorTheme(getTimelineStyles);
 
     return (
         <button

--- a/packages/orchestrator-ui-components/src/components/WfoTimeline/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTimeline/styles.ts
@@ -46,7 +46,7 @@ export const getTimelineStyles = ({ theme }: WfoTheme) => {
     const timelinePanelStyle = css({
         backgroundColor: theme.colors.body,
         borderRadius: theme.border.radius.medium,
-        outline: `${timelineOutlineWidthPx} solid white`, // todo use theme
+        outline: `${timelineOutlineWidthPx} solid ${theme.colors.emptyShade}`,
         height: timelineHeightPx,
         marginTop: timelineOutlineWidthPx,
         marginBottom: timelineOutlineWidthPx,
@@ -58,10 +58,8 @@ export const getTimelineStyles = ({ theme }: WfoTheme) => {
         paddingRight: theme.font.baseline * 4,
         position: 'sticky',
         top: timelineOutlineWidthPx,
-        zIndex: 2, // todo find out why Options button and the process icons got z-index.
+        zIndex: 2, // Some EUI components have a zIndex
         display: 'flex',
-
-        // opacity: 0.3,
 
         '& > button': {
             flexGrow: 2,

--- a/packages/orchestrator-ui-components/src/components/WfoTimeline/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTimeline/styles.ts
@@ -5,7 +5,12 @@ import { StepStatus } from '@/types';
 
 import { TimelinePosition } from './WfoTimeline';
 
-export const getStyles = ({ theme }: WfoTheme) => {
+export const getTimelineStyles = ({ theme }: WfoTheme) => {
+    const TIMELINE_HEIGHT = theme.base * 2.5;
+    const TIMELINE_OUTLINE_WIDTH = theme.base * 0.75;
+
+    const timelineHeightPx = `${TIMELINE_HEIGHT}px`;
+    const timelineOutlineWidthPx = `${TIMELINE_OUTLINE_WIDTH}px`;
     const emptyStepOuterDiameter = theme.base;
     const emptyStepInnerDiameter = theme.base / 2;
     const stepWithValueOuterDiameter = theme.base * 1.5;
@@ -41,15 +46,22 @@ export const getStyles = ({ theme }: WfoTheme) => {
     const timelinePanelStyle = css({
         backgroundColor: theme.colors.body,
         borderRadius: theme.border.radius.medium,
-        outline: '10px solid white', // todo use theme
-        marginBottom: '10px',
+        outline: `${timelineOutlineWidthPx} solid white`, // todo use theme
+        height: timelineHeightPx,
+        marginTop: timelineOutlineWidthPx,
+        marginBottom: timelineOutlineWidthPx,
         overflow: 'auto',
         scrollbarWidth: 'auto',
         paddingTop: theme.font.baseline * 2,
         paddingBottom: theme.font.baseline * 2,
         paddingLeft: theme.font.baseline * 4,
         paddingRight: theme.font.baseline * 4,
+        position: 'sticky',
+        top: timelineOutlineWidthPx,
+        zIndex: 2, // todo find out why Options button and the process icons got z-index.
         display: 'flex',
+
+        // opacity: 0.3,
 
         '& > button': {
             flexGrow: 2,
@@ -163,6 +175,8 @@ export const getStyles = ({ theme }: WfoTheme) => {
     });
 
     return {
+        TIMELINE_HEIGHT,
+        TIMELINE_OUTLINE_WIDTH,
         timelinePanelStyle,
         stepStyle,
         clickableStyle,

--- a/packages/orchestrator-ui-components/src/components/WfoTimeline/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTimeline/styles.ts
@@ -41,6 +41,8 @@ export const getStyles = ({ theme }: WfoTheme) => {
     const timelinePanelStyle = css({
         backgroundColor: theme.colors.body,
         borderRadius: theme.border.radius.medium,
+        outline: '10px solid white', // todo use theme
+        marginBottom: '10px',
         overflow: 'auto',
         scrollbarWidth: 'auto',
         paddingTop: theme.font.baseline * 2,

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStep.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStep.tsx
@@ -20,7 +20,7 @@ import { calculateTimeDifference, formatDate } from '@/utils';
 import { WfoStepStatusIcon } from '../WfoStepStatusIcon';
 import type { StepListItem } from '../WfoWorkflowStepList';
 import { getStepContent } from '../stepListUtils';
-import { getStyles } from '../styles';
+import { getWorkflowStepsStyles } from '../styles';
 import { WfoStepForm } from './WfoStepForm';
 
 export interface WfoStepProps {
@@ -58,7 +58,7 @@ export const WfoStep = React.forwardRef(
             stepDurationStyle,
             stepRowStyle,
             getStepToggleExpandStyle,
-        } = useWithOrchestratorTheme(getStyles);
+        } = useWithOrchestratorTheme(getWorkflowStepsStyles);
         const t = useTranslations('processes.steps');
         const hasHtmlMail =
             step.stateDelta?.hasOwnProperty('confirmation_mail');

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
@@ -35,14 +35,13 @@ export const WfoStepList = React.forwardRef(
         }: WfoStepListProps,
         reference: Ref<WfoStepListRef>,
     ) => {
-        // const { stepSpacerStyle } = useWithOrchestratorTheme(getStyles);
         const { NAVIGATION_HEIGHT } = useWithOrchestratorTheme(
             getPageTemplateStyles,
-        ); // nav height
+        );
         const { TIMELINE_HEIGHT, TIMELINE_OUTLINE_WIDTH } =
-            useWithOrchestratorTheme(getTimelineStyles); // timeline height + timeline outline width
+            useWithOrchestratorTheme(getTimelineStyles);
         const { SPACE_BETWEEN_STEPS, stepSpacerStyle } =
-            useWithOrchestratorTheme(getWorkflowStepsStyles); // space between steps
+            useWithOrchestratorTheme(getWorkflowStepsStyles);
         const scrollOffset =
             NAVIGATION_HEIGHT +
             TIMELINE_HEIGHT +

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
@@ -1,6 +1,6 @@
-import React, { Ref, useContext, useImperativeHandle, useRef } from 'react';
+import React, { Ref, useImperativeHandle, useRef } from 'react';
 
-import { ContentContext } from '@/components';
+import { useContentRef } from '@/components';
 import { useWithOrchestratorTheme } from '@/hooks';
 
 import { WfoStep } from '../WfoStep';
@@ -38,7 +38,7 @@ export const WfoStepList = React.forwardRef(
 
         const stepReferences = useRef(new Map<string, HTMLDivElement>());
 
-        const contentRef = useContext(ContentContext)?.contentRef;
+        const { contentRef } = useContentRef();
 
         let stepStartTime = startedAt;
 
@@ -68,7 +68,7 @@ export const WfoStepList = React.forwardRef(
                     if (targetRect) {
                         const { top } = targetRect;
                         contentRef?.current?.scrollBy({
-                            top: top - 122, // Timeline height (40) + Offset from top (10) + Space between steps (24) + Fixed menu bar (48)
+                            top: top - 122, // Todo: Timeline height (40) + Offset from top (10) + Space between steps (24) + Fixed menu bar (48)
                             behavior: 'smooth',
                         });
                     }

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
@@ -1,9 +1,11 @@
 import React, { Ref, useImperativeHandle, useRef } from 'react';
 
+import { getPageTemplateStyles } from '@/components/WfoPageTemplate/WfoPageTemplate/styles';
+import { getTimelineStyles } from '@/components/WfoTimeline/styles';
 import { useContentRef, useWithOrchestratorTheme } from '@/hooks';
 
 import { WfoStep } from '../WfoStep';
-import { getStyles } from '../styles';
+import { getWorkflowStepsStyles } from '../styles';
 import { StepListItem } from './../WfoWorkflowStepList';
 
 export type WfoStepListRef = {
@@ -33,7 +35,19 @@ export const WfoStepList = React.forwardRef(
         }: WfoStepListProps,
         reference: Ref<WfoStepListRef>,
     ) => {
-        const { stepSpacerStyle } = useWithOrchestratorTheme(getStyles);
+        // const { stepSpacerStyle } = useWithOrchestratorTheme(getStyles);
+        const { NAVIGATION_HEIGHT } = useWithOrchestratorTheme(
+            getPageTemplateStyles,
+        ); // nav height
+        const { TIMELINE_HEIGHT, TIMELINE_OUTLINE_WIDTH } =
+            useWithOrchestratorTheme(getTimelineStyles); // timeline height + timeline outline width
+        const { SPACE_BETWEEN_STEPS, stepSpacerStyle } =
+            useWithOrchestratorTheme(getWorkflowStepsStyles); // space between steps
+        const scrollOffset =
+            NAVIGATION_HEIGHT +
+            TIMELINE_HEIGHT +
+            TIMELINE_OUTLINE_WIDTH +
+            SPACE_BETWEEN_STEPS;
 
         const stepReferences = useRef(new Map<string, HTMLDivElement>());
 
@@ -59,7 +73,6 @@ export const WfoStepList = React.forwardRef(
                         );
                     });
 
-                    // Start of custom scrollIntoView
                     const targetRect = stepReferences.current
                         .get(stepId)
                         ?.getBoundingClientRect();
@@ -67,11 +80,10 @@ export const WfoStepList = React.forwardRef(
                     if (targetRect) {
                         const { top } = targetRect;
                         contentRef?.current?.scrollBy({
-                            top: top - 122, // Todo: Timeline height (40) + Offset from top (10) + Space between steps (24) + Fixed menu bar (48)
+                            top: top - scrollOffset,
                             behavior: 'smooth',
                         });
                     }
-                    // End of custom scrollIntoView
                 } catch {
                     console.error(
                         'Error scrolling to step with stepId ',

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
@@ -1,5 +1,6 @@
-import React, { Ref, useImperativeHandle, useRef } from 'react';
+import React, { Ref, useContext, useImperativeHandle, useRef } from 'react';
 
+import { ContentContext } from '@/components';
 import { useWithOrchestratorTheme } from '@/hooks';
 
 import { WfoStep } from '../WfoStep';
@@ -37,6 +38,8 @@ export const WfoStepList = React.forwardRef(
 
         const stepReferences = useRef(new Map<string, HTMLDivElement>());
 
+        const contentRef = useContext(ContentContext)?.contentRef;
+
         let stepStartTime = startedAt;
 
         useImperativeHandle(reference, () => ({
@@ -64,10 +67,8 @@ export const WfoStepList = React.forwardRef(
 
                     if (targetRect) {
                         const { top } = targetRect;
-                        // Todo: Check after implementing the fixed menu bar if this is still working.
-                        // Might need to target the actual div that is scrollable.
-                        window.scrollBy({
-                            top: top - 74, // Timeline height (40) + Offset from top (10) + Space between steps (24/2)
+                        contentRef?.current?.scrollBy({
+                            top: top - 122, // Timeline height (40) + Offset from top (10) + Space between steps (24) + Fixed menu bar (48)
                             behavior: 'smooth',
                         });
                     }

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
@@ -1,7 +1,6 @@
 import React, { Ref, useImperativeHandle, useRef } from 'react';
 
-import { useContentRef } from '@/components';
-import { useWithOrchestratorTheme } from '@/hooks';
+import { useContentRef, useWithOrchestratorTheme } from '@/hooks';
 
 import { WfoStep } from '../WfoStep';
 import { getStyles } from '../styles';

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
@@ -56,9 +56,22 @@ export const WfoStepList = React.forwardRef(
                             onTriggerExpandStepListItem(foundStepListItem),
                         );
                     });
-                    stepReferences.current.get(stepId)?.scrollIntoView({
-                        behavior: 'smooth',
-                    });
+
+                    // Start of custom scrollIntoView
+                    const targetRect = stepReferences.current
+                        .get(stepId)
+                        ?.getBoundingClientRect();
+
+                    if (targetRect) {
+                        const { top } = targetRect;
+                        // Todo: Check after implementing the fixed menu bar if this is still working.
+                        // Might need to target the actual div that is scrollable.
+                        window.scrollBy({
+                            top: top - 74, // Timeline height (40) + Offset from top (10) + Space between steps (24/2)
+                            behavior: 'smooth',
+                        });
+                    }
+                    // End of custom scrollIntoView
                 } catch {
                     console.error(
                         'Error scrolling to step with stepId ',

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepStatusIcon/WfoStepStatusIcon.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepStatusIcon/WfoStepStatusIcon.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/icons';
 import { StepStatus } from '@/types';
 
-import { getStyles } from '../styles';
+import { getWorkflowStepsStyles } from '../styles';
 
 export interface WfoStepStatusIconProps {
     stepStatus: StepStatus;
@@ -61,7 +61,7 @@ export const WfoStepStatusIcon = ({
         stepStateSuspendIconStyle,
         stepStatePendingIconStyle,
         stepStateFailedIconStyle,
-    } = useWithOrchestratorTheme(getStyles);
+    } = useWithOrchestratorTheme(getWorkflowStepsStyles);
 
     const [
         stepStateStyle,

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoWorkflowStepList/WfoStepListHeader.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoWorkflowStepList/WfoStepListHeader.tsx
@@ -16,7 +16,7 @@ import { WfoTextAnchor } from '@/components/WfoTextAnchor/WfoTextAnchor';
 import { useOrchestratorTheme, useWithOrchestratorTheme } from '@/hooks';
 import { WfoCode, WfoEyeFill } from '@/icons';
 
-import { getStyles } from '../styles';
+import { getWorkflowStepsStyles } from '../styles';
 
 export type WfoStepListHeaderProps = {
     allDetailToggleText: string;
@@ -56,7 +56,7 @@ export const WfoStepListHeader: FC<WfoStepListHeaderProps> = ({
         stepListContentStyle,
         stepListContentBoldTextStyle,
         stepListOptionsContainerStyle,
-    } = useWithOrchestratorTheme(getStyles);
+    } = useWithOrchestratorTheme(getWorkflowStepsStyles);
 
     const [isViewOptionOpen, setIsViewOptionOpen] = useState(false);
 

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/styles.ts
@@ -2,10 +2,15 @@ import { css } from '@emotion/react';
 
 import { WfoTheme } from '@/hooks';
 
-export const getStyles = ({ theme, toSecondaryColor }: WfoTheme) => {
+export const getWorkflowStepsStyles = ({
+    theme,
+    toSecondaryColor,
+}: WfoTheme) => {
+    const SPACE_BETWEEN_STEPS = theme.base * 1.5;
+
     const stepSpacerStyle = css({
         borderLeft: `1px solid ${theme.colors.darkShade}`,
-        height: '24px',
+        height: `${SPACE_BETWEEN_STEPS}px`,
         marginLeft: '36px',
     });
 
@@ -102,6 +107,7 @@ export const getStyles = ({ theme, toSecondaryColor }: WfoTheme) => {
         });
 
     return {
+        SPACE_BETWEEN_STEPS,
         stepDurationStyle,
         stepEmailContainerStyle,
         stepHeaderRightStyle,

--- a/packages/orchestrator-ui-components/src/hooks/index.ts
+++ b/packages/orchestrator-ui-components/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useCheckEngineStatus';
+export * from './useContentRef';
 export * from './useOrchestratorConfig';
 export * from './useOrchestratorTheme';
 export * from './usePolicy';

--- a/packages/orchestrator-ui-components/src/hooks/useContentRef.ts
+++ b/packages/orchestrator-ui-components/src/hooks/useContentRef.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { ContentContext } from '../components/WfoPageTemplate';
+
+export const useContentRef = () => ({
+    contentRef: useContext(ContentContext)?.contentRef,
+});

--- a/packages/orchestrator-ui-components/src/pages/processes/WfoStartProcessPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/processes/WfoStartProcessPage.tsx
@@ -15,7 +15,7 @@ import {
 import { PATH_TASKS, PATH_WORKFLOWS, WfoError, WfoLoading } from '@/components';
 import { UserInputFormWizard } from '@/components/WfoForms/UserInputFormWizard';
 import { WfoStepStatusIcon } from '@/components/WfoWorkflowSteps';
-import { getStyles } from '@/components/WfoWorkflowSteps/styles';
+import { getWorkflowStepsStyles } from '@/components/WfoWorkflowSteps/styles';
 import { useOrchestratorTheme, useWithOrchestratorTheme } from '@/hooks';
 import {
     HttpStatus,
@@ -124,7 +124,7 @@ export const WfoStartProcessPage = ({
     const { stepUserInput, hasNext } = form;
 
     const { getStepHeaderStyle, stepListContentBoldTextStyle } =
-        useWithOrchestratorTheme(getStyles);
+        useWithOrchestratorTheme(getWorkflowStepsStyles);
 
     const {
         data: timeLineItems = [],


### PR DESCRIPTION
#330 

- Making the timeline sticky at the top of the screen
- Introduces a ContentContext and a useContentRef to be used to easily refer to the reference of the scrollable content section. In this case used to call a `scrollBy(...)` on it.