### PR TITLE
1635 Adds allFieldValues parameter for override function

### DIFF
--- a/.changeset/lucky-otters-invite.md
+++ b/.changeset/lucky-otters-invite.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': minor
+---
+
+1635 Adds extra parameter ("allFieldValues") to the override function to have all data available when overriding a specific cell value

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoProductBlockKeyValueRow.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoProductBlockKeyValueRow.tsx
@@ -11,11 +11,12 @@ import { getStyles } from './styles';
 
 export type WfoProductBlockKeyValueRowProps = {
     fieldValue: FieldValue | RenderableFieldValue;
+    allFieldValues: FieldValue[];
 };
 
 export const WfoProductBlockKeyValueRow: FC<
     WfoProductBlockKeyValueRowProps
-> = ({ fieldValue }) => {
+> = ({ fieldValue, allFieldValues }) => {
     const { leftColumnStyle, rowStyle } = useWithOrchestratorTheme(getStyles);
     const { getOverriddenValue } = useSubscriptionDetailValueOverride();
 
@@ -40,7 +41,7 @@ export const WfoProductBlockKeyValueRow: FC<
                 <b>{camelToHuman(field)}</b>
             </td>
             <td>
-                {getOverriddenValue(fieldValue) ?? (
+                {getOverriddenValue(fieldValue, allFieldValues) ?? (
                     <WfoProductBlockValue value={value} />
                 )}
             </td>

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoProductBlockKeyValueRow.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoProductBlockKeyValueRow.tsx
@@ -11,7 +11,7 @@ import { getStyles } from './styles';
 
 export type WfoProductBlockKeyValueRowProps = {
     fieldValue: FieldValue | RenderableFieldValue;
-    allFieldValues: FieldValue[];
+    allFieldValues: FieldValue[] | RenderableFieldValue[];
 };
 
 export const WfoProductBlockKeyValueRow: FC<

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoSubscriptionProductBlock.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock/WfoSubscriptionProductBlock.tsx
@@ -246,6 +246,9 @@ export const WfoSubscriptionProductBlock = ({
                                                     fieldValue={
                                                         productBlockInstanceValue
                                                     }
+                                                    allFieldValues={
+                                                        productBlock.productBlockInstanceValues
+                                                    }
                                                     key={index}
                                                 />
                                             );

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/overrides/useSubscriptionDetailValueOverride.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/overrides/useSubscriptionDetailValueOverride.ts
@@ -13,7 +13,7 @@ export const useSubscriptionDetailValueOverride = () => {
 
     const getOverriddenValue = (
         fieldValue: FieldValue | RenderableFieldValue,
-        allFieldValues: FieldValue[],
+        allFieldValues: FieldValue[] | RenderableFieldValue[],
     ): React.ReactNode | null => {
         if (!valueOverrideConfiguration) {
             return null;

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/overrides/useSubscriptionDetailValueOverride.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/overrides/useSubscriptionDetailValueOverride.ts
@@ -13,6 +13,7 @@ export const useSubscriptionDetailValueOverride = () => {
 
     const getOverriddenValue = (
         fieldValue: FieldValue | RenderableFieldValue,
+        allFieldValues: FieldValue[],
     ): React.ReactNode | null => {
         if (!valueOverrideConfiguration) {
             return null;
@@ -23,7 +24,7 @@ export const useSubscriptionDetailValueOverride = () => {
 
         // This check is needed because TS does not infer the type correctly
         if (renderFunctionForField) {
-            return renderFunctionForField(fieldValue);
+            return renderFunctionForField(fieldValue, allFieldValues);
         }
 
         return null;

--- a/packages/orchestrator-ui-components/src/rtk/slices/orchestratorComponentOverride.ts
+++ b/packages/orchestrator-ui-components/src/rtk/slices/orchestratorComponentOverride.ts
@@ -6,6 +6,7 @@ import { FieldValue, RenderableFieldValue, SubscriptionDetail } from '@/types';
 
 export type ValueOverrideFunction = (
     fieldValue: FieldValue | RenderableFieldValue,
+    allFieldValues: FieldValue[],
 ) => ReactNode;
 export type ValueOverrideConfiguration = Record<string, ValueOverrideFunction>;
 

--- a/packages/orchestrator-ui-components/src/rtk/slices/orchestratorComponentOverride.ts
+++ b/packages/orchestrator-ui-components/src/rtk/slices/orchestratorComponentOverride.ts
@@ -6,7 +6,7 @@ import { FieldValue, RenderableFieldValue, SubscriptionDetail } from '@/types';
 
 export type ValueOverrideFunction = (
     fieldValue: FieldValue | RenderableFieldValue,
-    allFieldValues: FieldValue[],
+    allFieldValues: FieldValue[] | RenderableFieldValue[],
 ) => ReactNode;
 export type ValueOverrideConfiguration = Record<string, ValueOverrideFunction>;
 


### PR DESCRIPTION
In case consumers want to override values in the product block tables, the override function provides now a second parameter containing all key-values