### PR TITLE
1210 workflow list table multiple subscriptions

### DIFF
--- a/.changeset/rude-starfishes-divide.md
+++ b/.changeset/rude-starfishes-divide.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': minor
+---
+
+1210 Adds a badge with number of subscriptions not shown in the affected-subscriptions cell on the process list page

--- a/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 import {
     FilterQuery,
@@ -99,6 +100,7 @@ export const WfoProcessesList = ({
     const t = useTranslations('processes.index');
     const tError = useTranslations('errors');
     const { showToastMessage } = useShowToastMessage();
+    const router = useRouter();
 
     const defaultTableColumns: WfoAdvancedTableColumnConfig<ProcessListItem> = {
         workflowName: {
@@ -153,14 +155,12 @@ export const WfoProcessesList = ({
             columnType: ColumnType.DATA,
             label: t('subscriptions'),
             width: '425px',
-            renderData: ({ page: subscriptions }) => (
+            renderData: ({ page: subscriptions }, { processId }) => (
                 <WfoProcessListSubscriptionsCell
                     subscriptions={subscriptions}
                     numberOfSubscriptionsToRender={1}
                     onMoreSubscriptionsClick={() =>
-                        console.log('Show modal for more subscriptions:', {
-                            subscriptions,
-                        })
+                        router.push(`${PATH_WORKFLOWS}/${processId}`)
                     }
                 />
             ),

--- a/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoProcessList/WfoProcessesList.tsx
@@ -157,6 +157,11 @@ export const WfoProcessesList = ({
                 <WfoProcessListSubscriptionsCell
                     subscriptions={subscriptions}
                     numberOfSubscriptionsToRender={1}
+                    onMoreSubscriptionsClick={() =>
+                        console.log('Show modal for more subscriptions:', {
+                            subscriptions,
+                        })
+                    }
                 />
             ),
             renderDetails: ({ page: subscriptions }) => (

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoTable/WfoToolTip.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoTable/WfoToolTip.tsx
@@ -21,6 +21,7 @@ export const WfoToolTip: FC<WfoToolTipProps> = ({
             content={tooltipContent}
             css={{ maxWidth: 'fit-content' }}
             repositionOnScroll
+            display="block"
         >
             <div css={{ width: '100%' }}>{children}</div>
         </EuiToolTip>

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -212,7 +212,8 @@
             "started": "Started",
             "lastModified": "Last modified",
             "workflowTarget": "Target",
-            "productTag": "Product tag"
+            "productTag": "Product tag",
+            "showAllRelatedSubscriptions": "Show all related subscriptions"
         },
         "detail": {
             "retry": "Retry",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -209,7 +209,8 @@
             "started": "Starttijd",
             "lastModified": "Aangepast op",
             "workflowTarget": "Target",
-            "productTag": "Product tag"
+            "productTag": "Product tag",
+            "showAllRelatedSubscriptions": "Toon alle gerelateerde subscriptions"
         },
         "detail": {
             "retry": "Probeer opnieuw",

--- a/packages/orchestrator-ui-components/src/pages/processes/WfoProcessListSubscriptionsCell.tsx
+++ b/packages/orchestrator-ui-components/src/pages/processes/WfoProcessListSubscriptionsCell.tsx
@@ -86,18 +86,6 @@ export const WfoProcessListSubscriptionsCell: FC<
                     >
                         + {numberOfNotVisibleSubscriptions}
                     </WfoBadge>
-
-                    // <div
-                    //     css={{
-                    //         backgroundColor: 'hotpink',
-                    //         padding: '3px',
-                    //         borderRadius: '50%',
-                    //         fontSize: '0.75rem',
-                    //         // flex: '0 0 auto',
-                    //     }}
-                    // >
-                    //     {`+${numberOfNotVisibleSubscriptions}`}
-                    // </div>
                 )}
             </EuiFlexGroup>
         </>

--- a/packages/orchestrator-ui-components/src/pages/processes/WfoProcessListSubscriptionsCell.tsx
+++ b/packages/orchestrator-ui-components/src/pages/processes/WfoProcessListSubscriptionsCell.tsx
@@ -5,7 +5,9 @@ import Link from 'next/link';
 
 import { EuiFlexGroup } from '@elastic/eui';
 
-import { Subscription } from '../../types';
+import { WfoBadge } from '@/components';
+import { useOrchestratorTheme } from '@/hooks';
+import { Subscription } from '@/types';
 
 export const RENDER_ALL = 'RENDER_ALL';
 export enum RenderDirection {
@@ -17,6 +19,7 @@ export type WfoProcessesListSubscriptionsCellProps = {
     subscriptions: Pick<Subscription, 'subscriptionId' | 'description'>[];
     numberOfSubscriptionsToRender?: number | typeof RENDER_ALL;
     renderDirection?: RenderDirection;
+    onMoreSubscriptionsClick?: () => void;
 };
 
 export const WfoProcessListSubscriptionsCell: FC<
@@ -25,7 +28,10 @@ export const WfoProcessListSubscriptionsCell: FC<
     subscriptions,
     numberOfSubscriptionsToRender = RENDER_ALL,
     renderDirection = RenderDirection.HORIZONTAL,
+    onMoreSubscriptionsClick = () => {},
 }) => {
+    const { theme, toSecondaryColor } = useOrchestratorTheme();
+
     const { length } = subscriptions;
 
     if (length === 0) {
@@ -47,8 +53,9 @@ export const WfoProcessListSubscriptionsCell: FC<
                         ? 'row'
                         : 'column'
                 }
+                alignItems="center"
                 gutterSize={
-                    renderDirection === RenderDirection.HORIZONTAL ? 'm' : 'xs'
+                    renderDirection === RenderDirection.HORIZONTAL ? 's' : 'xs'
                 }
             >
                 {visibleSubscriptions.map((subscription) => (
@@ -63,8 +70,34 @@ export const WfoProcessListSubscriptionsCell: FC<
                         {subscription.description}
                     </Link>
                 ))}
+
                 {numberOfNotVisibleSubscriptions > 0 && (
-                    <span>{`(+${numberOfNotVisibleSubscriptions})`}</span>
+                    <WfoBadge
+                        textColor={theme.colors.primaryText}
+                        color={toSecondaryColor(theme.colors.primary)}
+                        onClick={() => onMoreSubscriptionsClick()}
+                        iconOnClick={() => onMoreSubscriptionsClick()}
+                        onClickAriaLabel={
+                            'toDo: Show all related subscriptions'
+                        }
+                        iconOnClickAriaLabel={
+                            'toDo: Show all related subscriptions'
+                        }
+                    >
+                        + {numberOfNotVisibleSubscriptions}
+                    </WfoBadge>
+
+                    // <div
+                    //     css={{
+                    //         backgroundColor: 'hotpink',
+                    //         padding: '3px',
+                    //         borderRadius: '50%',
+                    //         fontSize: '0.75rem',
+                    //         // flex: '0 0 auto',
+                    //     }}
+                    // >
+                    //     {`+${numberOfNotVisibleSubscriptions}`}
+                    // </div>
                 )}
             </EuiFlexGroup>
         </>

--- a/packages/orchestrator-ui-components/src/pages/processes/WfoProcessListSubscriptionsCell.tsx
+++ b/packages/orchestrator-ui-components/src/pages/processes/WfoProcessListSubscriptionsCell.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FC } from 'react';
 
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 
 import { EuiFlexGroup } from '@elastic/eui';
@@ -31,6 +32,7 @@ export const WfoProcessListSubscriptionsCell: FC<
     onMoreSubscriptionsClick = () => {},
 }) => {
     const { theme, toSecondaryColor } = useOrchestratorTheme();
+    const t = useTranslations('processes.index');
 
     const { length } = subscriptions;
 
@@ -77,12 +79,8 @@ export const WfoProcessListSubscriptionsCell: FC<
                         color={toSecondaryColor(theme.colors.primary)}
                         onClick={() => onMoreSubscriptionsClick()}
                         iconOnClick={() => onMoreSubscriptionsClick()}
-                        onClickAriaLabel={
-                            'toDo: Show all related subscriptions'
-                        }
-                        iconOnClickAriaLabel={
-                            'toDo: Show all related subscriptions'
-                        }
+                        onClickAriaLabel={t('showAllRelatedSubscriptions')}
+                        iconOnClickAriaLabel={t('showAllRelatedSubscriptions')}
                     >
                         + {numberOfNotVisibleSubscriptions}
                     </WfoBadge>


### PR DESCRIPTION
#1210 

- Adds a badge with number of subscriptions not shown in the affected-subscriptions cell on the process list page
- The badge is always visible, the text left of it will get cut off in favor of the badge
![image](https://github.com/user-attachments/assets/c0ecec85-1fc9-4a8c-a203-34e041aa95c3)
