### PR TITLE
2015 fix WfoProcessSubscriptionDelta not showing the old subscription

### DIFF
--- a/.changeset/evil-roses-kick.md
+++ b/.changeset/evil-roses-kick.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+Fix regression in subscription delta

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoWorkflowStepList/WfoWorkflowStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoWorkflowStepList/WfoWorkflowStepList.tsx
@@ -47,7 +47,10 @@ export const WfoProcessSubscriptionDelta = ({
         data?.current_state?.subscription?.subscription_id ?? '';
     const newText = data?.current_state?.subscription ?? null;
     const oldSubscriptions = data?.current_state?.__old_subscriptions__ || {};
-    const oldSubscription = subscriptionId in oldSubscriptions;
+    const oldSubscription =
+        subscriptionId in oldSubscriptions
+            ? oldSubscriptions[subscriptionId]
+            : null;
     const oldText = oldSubscription || null;
 
     return isFetching ? (


### PR DESCRIPTION
Fixes a regression in WfoProcessSubscriptionDelta.

## Before

![image](https://github.com/user-attachments/assets/0282434b-7c38-4340-ae1a-548b56750903)

## After

![image](https://github.com/user-attachments/assets/87508579-682e-4586-899c-724fd3866003)


Closes #2015 