### PR TITLE
1935 Fixes dropdown menu-button style

### DIFF
--- a/.changeset/curvy-masks-lie.md
+++ b/.changeset/curvy-masks-lie.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1935 Fixes style in WfoContentHeader. This makes the dropdown menu attached to the action button again

--- a/packages/orchestrator-ui-components/src/components/WfoContentHeader/WfoContentHeader.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoContentHeader/WfoContentHeader.tsx
@@ -42,7 +42,10 @@ export const WfoContentHeader: FC<WfoContentHeaderProps> = ({
 
             {children && (
                 <EuiFlexItem grow={0}>
-                    <EuiFlexGroup justifyContent="flexEnd">
+                    <EuiFlexGroup
+                        justifyContent="flexEnd"
+                        alignItems="flexStart"
+                    >
                         <WfoRenderElementOrString>
                             {children}
                         </WfoRenderElementOrString>


### PR DESCRIPTION
Making the dropdown menu attached to the action button again, The actual change is needed in the `WfoContentHeader` where the right colum should not use up all available vertical space. This makes the dropdown menu attach to the action button again.

![image](https://github.com/user-attachments/assets/00086ce4-309a-406c-82e5-7370f02964e9)

