### PR TITLE
Disable workflow starts that are not allowed for the current user

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WfoStartButton/WfoStartWorkflowComboBox.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartButton/WfoStartWorkflowComboBox.tsx
@@ -28,6 +28,7 @@ export const WfoStartWorkflowButtonComboBox = () => {
                 productId: option.productId,
             },
             label: option.productName || '',
+            disabled: !option.isAllowed,
         }));
 
     const handleOptionChange = async (selectedProduct: StartComboBoxOption) => {

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/startOptions.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/startOptions.ts
@@ -12,6 +12,7 @@ const workflowOptionsQuery = `
         workflows(first: 1000000, after: 0, filterBy: [{ field: "target", value: "${WorkflowTarget.CREATE}"}]) {
             page {
                 name
+                isAllowed
                 products {
                     productType
                     productId
@@ -36,6 +37,7 @@ const taskOptionsQuery = `
 
 type WorkflowOption = {
     workflowName: WorkflowDefinition['name'];
+    isAllowed: WorkflowDefinition['isAllowed'];
     productName: ProductDefinition['name'];
     productId: ProductDefinition['productId'];
     productType: ProductDefinition['productType'];
@@ -44,6 +46,7 @@ type WorkflowOption = {
 
 type WorkflowOptionsResult = StartOptionsResult<{
     name: WorkflowDefinition['name'];
+    isAllowed: WorkflowDefinition['isAllowed'];
     products: {
         name: ProductDefinition['name'];
         productId: ProductDefinition['productId'];
@@ -75,9 +78,11 @@ const startButtonOptionsApi = orchestratorApi.injectEndpoints({
                 const workflows = response?.workflows?.page || [];
                 workflows.forEach((workflow) => {
                     const workflowName = workflow.name;
+                    const workflowIsAllowed = workflow.isAllowed;
                     workflow.products.forEach((product) => {
                         startOptions.push({
                             workflowName,
+                            isAllowed: workflowIsAllowed,
                             productName: product.name,
                             productId: product.productId,
                             productType: product.productType,

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -262,6 +262,7 @@ export interface WorkflowDefinition {
     description: string;
     target: WorkflowTarget;
     isTask: boolean;
+    isAllowed: boolean;
     products: Pick<ProductDefinition, 'tag' | 'productId' | 'name'>[];
     createdAt: string;
 }
@@ -405,6 +406,7 @@ export type StartComboBoxOption = {
         productId?: string;
     };
     label: string;
+    disabled?: boolean;
 };
 
 export interface GraphQlResultPage<T> {


### PR DESCRIPTION
Depends on a backend change.
Closes #2013 

![image](https://github.com/user-attachments/assets/b9811038-f4be-458e-9dc9-3b0b073dca47)
When a user is not allowed to start a workflow according to the backend, the options are grayed out.