### PR TITLE
Reflect RBAC rules from backend in GUI

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WfoForms/UserInputForm.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/UserInputForm.tsx
@@ -58,6 +58,7 @@ interface IProps {
     userInput: object;
     isTask?: boolean;
     isResuming?: boolean;
+    disabled?: boolean;
 }
 
 interface Buttons {
@@ -433,6 +434,7 @@ export function WfoUserInputForm({
     userInput,
     isTask = false,
     isResuming = false,
+    disabled = false,
 }: IProps) {
     const t = useTranslations('pydanticForms.userInputForm');
     const tDialog = useTranslations('confirmationDialog');
@@ -544,6 +546,7 @@ export function WfoUserInputForm({
                         openLeavePageDialog(previous, t('previousQuestion')),
                     );
                 }}
+                disabled={disabled}
             >
                 {buttons.previous.text ?? t('previous')}
             </EuiButton>
@@ -586,6 +589,7 @@ export function WfoUserInputForm({
                 color={buttons.next.color ?? 'primary'}
                 isLoading={processing}
                 type="submit"
+                disabled={disabled}
             >
                 {buttons.next.text ?? t('next')}
             </EuiButton>
@@ -603,6 +607,7 @@ export function WfoUserInputForm({
                         : () => <WfoPlayFill color="#FFF" />
                 }
                 iconSide="right"
+                disabled={disabled}
             >
                 {buttons.next.text ?? t(nextButtonTranslationKey)}
             </EuiButton>
@@ -653,6 +658,7 @@ export function WfoUserInputForm({
                             showInlineError={true}
                             validate="onSubmit"
                             model={userInput}
+                            disabled={disabled}
                         >
                             <AutoFields omitFields={['buttons']} />
                             {/* Show top level validation info about backend validation */}

--- a/packages/orchestrator-ui-components/src/components/WfoForms/UserInputFormWizard.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/UserInputFormWizard.tsx
@@ -35,6 +35,7 @@ interface UserInputFormWizardProps {
     isTask: boolean;
     hasNext?: boolean;
     isResuming?: boolean;
+    allowSubmit?: boolean;
 }
 
 function stop(e: React.SyntheticEvent) {
@@ -51,6 +52,7 @@ export const UserInputFormWizard = ({
     cancel,
     isTask,
     isResuming = false,
+    allowSubmit = true,
 }: UserInputFormWizardProps) => {
     const router = useRouter();
     const [forms, setForms] = useState<Form[]>([
@@ -119,6 +121,7 @@ export const UserInputFormWizard = ({
             userInput={currentUserInput}
             isTask={isTask}
             isResuming={isResuming}
+            disabled={!allowSubmit}
         />
     );
 };

--- a/packages/orchestrator-ui-components/src/components/WfoStartButton/WfoStartTaskComboBox.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartButton/WfoStartTaskComboBox.tsx
@@ -24,6 +24,7 @@ export const WfoStartTaskButtonComboBox = () => {
                 workflowName: option.name,
             },
             label: option.description ?? option.name,
+            disabled: option.isAllowed === false,
         }))
         .sort((taskA, taskB) => taskA.label.localeCompare(taskB.label));
 

--- a/packages/orchestrator-ui-components/src/components/WfoStartButton/WfoStartWorkflowComboBox.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartButton/WfoStartWorkflowComboBox.tsx
@@ -28,6 +28,7 @@ export const WfoStartWorkflowButtonComboBox = () => {
                 productId: option.productId,
             },
             label: option.productName || '',
+            disabled: !option.isAllowed,
         }));
 
     const handleOptionChange = async (selectedProduct: StartComboBoxOption) => {

--- a/packages/orchestrator-ui-components/src/components/WfoStartButton/WfoStartWorkflowComboBox.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartButton/WfoStartWorkflowComboBox.tsx
@@ -28,7 +28,7 @@ export const WfoStartWorkflowButtonComboBox = () => {
                 productId: option.productId,
             },
             label: option.productName || '',
-            disabled: !option.isAllowed,
+            disabled: option.isAllowed === false,
         }));
 
     const handleOptionChange = async (selectedProduct: StartComboBoxOption) => {

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStep.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStep.tsx
@@ -15,6 +15,7 @@ import { useOrchestratorTheme, useWithOrchestratorTheme } from '@/hooks';
 import { WfoChevronDown, WfoChevronUp } from '@/icons';
 import type { EmailState } from '@/types';
 import { StepStatus } from '@/types';
+import { FormUserPermissions } from '@/types/forms';
 import { calculateTimeDifference, formatDate } from '@/utils';
 
 import { WfoStepStatusIcon } from '../WfoStepStatusIcon';
@@ -32,6 +33,7 @@ export interface WfoStepProps {
     isTask: boolean;
     isStartStep?: boolean;
     processId?: string;
+    userPermissions: FormUserPermissions;
 }
 
 export const WfoStep = React.forwardRef(
@@ -45,6 +47,7 @@ export const WfoStep = React.forwardRef(
             isStartStep = false,
             isTask,
             processId,
+            userPermissions,
         }: WfoStepProps,
         ref: LegacyRef<HTMLDivElement>,
     ) => {
@@ -211,6 +214,7 @@ export const WfoStep = React.forwardRef(
                             userInputForm={userInputForm}
                             isTask={isTask}
                             processId={processId}
+                            userPermissions={userPermissions}
                         />
                     )}
                 </EuiPanel>

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStepForm.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStepForm.tsx
@@ -6,18 +6,20 @@ import { UserInputFormWizard, WfoError, WfoLoading } from '@/components';
 import { useOrchestratorTheme } from '@/hooks';
 import { HttpStatus } from '@/rtk';
 import { useResumeProcessMutation } from '@/rtk/endpoints/forms';
-import { InputForm } from '@/types/forms';
+import { FormUserPermissions, InputForm } from '@/types/forms';
 
 interface WfoStepFormProps {
     userInputForm: InputForm;
     isTask: boolean;
     processId?: string;
+    userPermissions: FormUserPermissions;
 }
 
 export const WfoStepForm = ({
     userInputForm,
     isTask,
     processId,
+    userPermissions,
 }: WfoStepFormProps) => {
     const [isProcessing, setIsProcessing] = useState<boolean>(false);
     const [hasError, setHasError] = useState<boolean>(false);
@@ -57,6 +59,7 @@ export const WfoStepForm = ({
                     hasNext={false}
                     isTask={isTask}
                     isResuming={true}
+                    allowSubmit={userPermissions.inputAllowed}
                 />
             )}
         </EuiFlexItem>

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStepForm.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStep/WfoStepForm.tsx
@@ -59,7 +59,7 @@ export const WfoStepForm = ({
                     hasNext={false}
                     isTask={isTask}
                     isResuming={true}
-                    allowSubmit={userPermissions.inputAllowed}
+                    allowSubmit={userPermissions.resumeAllowed}
                 />
             )}
         </EuiFlexItem>

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoStepList/WfoStepList.tsx
@@ -3,6 +3,7 @@ import React, { Ref, useImperativeHandle, useRef } from 'react';
 import { getPageTemplateStyles } from '@/components/WfoPageTemplate/WfoPageTemplate/styles';
 import { getTimelineStyles } from '@/components/WfoTimeline/styles';
 import { useContentRef, useWithOrchestratorTheme } from '@/hooks';
+import { FormUserPermissions } from '@/types/forms';
 
 import { WfoStep } from '../WfoStep';
 import { getWorkflowStepsStyles } from '../styles';
@@ -19,6 +20,7 @@ export type WfoStepListProps = {
     onTriggerExpandStepListItem: (stepListItem: StepListItem) => void;
     isTask: boolean;
     processId: string;
+    userPermissions: FormUserPermissions;
 };
 
 export const WfoStepList = React.forwardRef(
@@ -30,6 +32,7 @@ export const WfoStepList = React.forwardRef(
             onTriggerExpandStepListItem,
             isTask,
             processId,
+            userPermissions,
         }: WfoStepListProps,
         reference: Ref<WfoStepListRef>,
     ) => {
@@ -116,6 +119,7 @@ export const WfoStepList = React.forwardRef(
                             isStartStep={index === 0}
                             isTask={isTask}
                             processId={processId}
+                            userPermissions={userPermissions}
                         />
                     </div>
                 ))}

--- a/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoWorkflowStepList/WfoWorkflowStepList.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoWorkflowSteps/WfoWorkflowStepList/WfoWorkflowStepList.tsx
@@ -13,7 +13,7 @@ import WfoDiff from '@/components/WfoDiff/WfoDiff';
 import { WfoTraceback } from '@/components/WfoWorkflowSteps/WfoTraceback/WfoTraceback';
 import { useGetRawProcessDetailQuery } from '@/rtk/endpoints/processDetail';
 import { ProcessStatus, Step, StepStatus } from '@/types';
-import { InputForm } from '@/types/forms';
+import { FormUserPermissions, InputForm } from '@/types/forms';
 
 export type StepListItem = {
     step: Step;
@@ -29,6 +29,7 @@ export interface WfoWorkflowStepListProps {
     processId: string;
     isTask: boolean;
     userInputForm?: InputForm;
+    userPermissions: FormUserPermissions;
 }
 
 export const WfoProcessRawData = ({ processId }: { processId: string }) => {
@@ -73,6 +74,7 @@ export const WfoWorkflowStepList = React.forwardRef(
             processId,
             isTask,
             userInputForm,
+            userPermissions,
         }: WfoWorkflowStepListProps,
         reference: Ref<WfoStepListRef>,
     ) => {
@@ -212,6 +214,7 @@ export const WfoWorkflowStepList = React.forwardRef(
                         }
                         processId={processId}
                         onTriggerExpandStepListItem={handleExpandStepListItem}
+                        userPermissions={userPermissions}
                     />
                 )}
             </>

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -317,7 +317,8 @@
                     "no_validate_workflow": "This subscription can not be validated as the product has no validate workflows.",
                     "not_in_sync": "This subscription can not be modified because it is not in-sync. This means there is some error in the registration of the subscription or that it is being modified by another workflow.",
                     "relations_not_in_sync": "This subscription can not be modified because some related subscriptions are not in-sync. Locked subscriptions: {locked_relations}",
-                    "no_modify_subscription_in_use_by_others": "This subscription can not be modified because it is in use by one or more other subscriptions: {unterminated_parents}"
+                    "no_modify_subscription_in_use_by_others": "This subscription can not be modified because it is in use by one or more other subscriptions: {unterminated_parents}",
+                    "insufficient_workflow_permissions": "Insufficient user permissions to run this workflow"
                 }
             },
             "subscriptionInstanceId": "Instance ID",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -314,7 +314,8 @@
                     "no_validate_workflow": "Deze subscription kan niet worden gevalideerd omdat het product geen validate workflows heeft.",
                     "not_in_sync": "Deze subscription kan niet worden gewijzigd omdat het niet in-sync is. Dit betekent dat er een fout zit in de registratie van de subscription of dat het wordt gewijzigd door een andere workflow.",
                     "relations_not_in_sync": "Deze subscription kan niet worden gewijzigd omdat sommige gerelateerde subscriptions niet in-sync zijn. Geblokkeerde subscriptions: {locked_relations}",
-                    "no_modify_subscription_in_use_by_others": "Deze subscription kan niet worden gewijzigd omdat het in gebruik is door een of meer andere subscriptions: {unterminated_parents}"
+                    "no_modify_subscription_in_use_by_others": "Deze subscription kan niet worden gewijzigd omdat het in gebruik is door een of meer andere subscriptions: {unterminated_parents}",
+                    "insufficient_workflow_permissions": "Onvoldoende toestemming om deze actie uit te kunnen voeren"
                 }
             },
             "subscriptionInstanceId": "Instance ID",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -315,7 +315,7 @@
                     "not_in_sync": "Deze subscription kan niet worden gewijzigd omdat het niet in-sync is. Dit betekent dat er een fout zit in de registratie van de subscription of dat het wordt gewijzigd door een andere workflow.",
                     "relations_not_in_sync": "Deze subscription kan niet worden gewijzigd omdat sommige gerelateerde subscriptions niet in-sync zijn. Geblokkeerde subscriptions: {locked_relations}",
                     "no_modify_subscription_in_use_by_others": "Deze subscription kan niet worden gewijzigd omdat het in gebruik is door een of meer andere subscriptions: {unterminated_parents}",
-                    "insufficient_workflow_permissions": "Onvoldoende toestemming om deze actie uit te kunnen voeren"
+                    "insufficient_workflow_permissions": "Onvoldoende rechten om deze actie uit te kunnen voeren"
                 }
             },
             "subscriptionInstanceId": "Instance ID",

--- a/packages/orchestrator-ui-components/src/pages/processes/WfoProcessDetail.tsx
+++ b/packages/orchestrator-ui-components/src/pages/processes/WfoProcessDetail.tsx
@@ -122,6 +122,7 @@ export const WfoProcessDetail = ({
 
     const retryButtonIsDisabled =
         buttonsAreDisabled ||
+        processDetail?.userPermissions!.retryAllowed === false ||
         !listIncludesStatus(
             [
                 ProcessStatus.FAILED,
@@ -133,12 +134,14 @@ export const WfoProcessDetail = ({
         );
     const abortButtonIsDisabled =
         buttonsAreDisabled ||
+        processDetail?.userPermissions!.abortAllowed === false ||
         listIncludesStatus(
             [ProcessStatus.COMPLETED, ProcessStatus.ABORTED],
             processDetail?.lastStatus,
         );
     const deleteButtonIsDisabled =
         buttonsAreDisabled ||
+        processDetail?.userPermissions!.abortAllowed === false ||
         listIncludesStatus([ProcessStatus.RUNNING], processDetail?.lastStatus);
 
     const processIsTask = processDetail?.isTask === true;

--- a/packages/orchestrator-ui-components/src/pages/processes/WfoProcessDetail.tsx
+++ b/packages/orchestrator-ui-components/src/pages/processes/WfoProcessDetail.tsx
@@ -134,14 +134,12 @@ export const WfoProcessDetail = ({
         );
     const abortButtonIsDisabled =
         buttonsAreDisabled ||
-        processDetail?.userPermissions!.abortAllowed === false ||
         listIncludesStatus(
             [ProcessStatus.COMPLETED, ProcessStatus.ABORTED],
             processDetail?.lastStatus,
         );
     const deleteButtonIsDisabled =
         buttonsAreDisabled ||
-        processDetail?.userPermissions!.abortAllowed === false ||
         listIncludesStatus([ProcessStatus.RUNNING], processDetail?.lastStatus);
 
     const processIsTask = processDetail?.isTask === true;

--- a/packages/orchestrator-ui-components/src/pages/processes/WfoProcessDetailPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/processes/WfoProcessDetailPage.tsx
@@ -87,6 +87,7 @@ export const WfoProcessDetailPage = ({
                         userInputForm={processDetail.form}
                         startedAt={processDetail.startedAt}
                         isTask={isTask}
+                        userPermissions={processDetail.userPermissions}
                     />
                 )) || <h1>Invalid processId</h1>}
         </WfoProcessDetail>

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/processDetail.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/processDetail.ts
@@ -28,7 +28,7 @@ export const processDetailQuery = `query ProcessDetail($processId: String!) {
                 traceback
                 userPermissions {
                     retryAllowed
-                    inputAllowed
+                    resumeAllowed
                 }
                 steps {
                     name

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/processDetail.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/processDetail.ts
@@ -26,6 +26,11 @@ export const processDetailQuery = `query ProcessDetail($processId: String!) {
                 isTask
                 form
                 traceback
+                userPermissions {
+                    retryAllowed
+                    abortAllowed
+                    inputAllowed
+                }
                 steps {
                     name
                     status

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/processDetail.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/processDetail.ts
@@ -28,7 +28,6 @@ export const processDetailQuery = `query ProcessDetail($processId: String!) {
                 traceback
                 userPermissions {
                     retryAllowed
-                    abortAllowed
                     inputAllowed
                 }
                 steps {

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/startOptions.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/startOptions.ts
@@ -29,6 +29,7 @@ const taskOptionsQuery = `
         workflows(first: 1000000, after: 0, filterBy: [{ field: "isTask", value: "true"}]) {
             page {
                 name
+                isAllowed
                 description
             }
         }
@@ -59,7 +60,10 @@ export type StartOptionsResponse<StartOption> = {
     startOptions: StartOption[];
 };
 
-type TaskOption = Pick<WorkflowDefinition, 'name' | 'description'>;
+type TaskOption = Pick<
+    WorkflowDefinition,
+    'name' | 'isAllowed' | 'description'
+>;
 type TaskOptionsResult = StartOptionsResult<TaskOption>;
 
 const startButtonOptionsApi = orchestratorApi.injectEndpoints({
@@ -78,11 +82,10 @@ const startButtonOptionsApi = orchestratorApi.injectEndpoints({
                 const workflows = response?.workflows?.page || [];
                 workflows.forEach((workflow) => {
                     const workflowName = workflow.name;
-                    const workflowIsAllowed = workflow.isAllowed;
                     workflow.products.forEach((product) => {
                         startOptions.push({
                             workflowName,
-                            isAllowed: workflowIsAllowed,
+                            isAllowed: workflow.isAllowed,
                             productName: product.name,
                             productId: product.productId,
                             productType: product.productType,
@@ -102,6 +105,7 @@ const startButtonOptionsApi = orchestratorApi.injectEndpoints({
                 return {
                     startOptions: response.workflows.page.map((option) => ({
                         name: option.name,
+                        isAllowed: option.isAllowed,
                         description: option.description,
                     })),
                 };

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/startOptions.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/startOptions.ts
@@ -12,6 +12,7 @@ const workflowOptionsQuery = `
         workflows(first: 1000000, after: 0, filterBy: [{ field: "target", value: "${WorkflowTarget.CREATE}"}]) {
             page {
                 name
+                isAllowed
                 products {
                     productType
                     productId
@@ -36,6 +37,7 @@ const taskOptionsQuery = `
 
 type WorkflowOption = {
     workflowName: WorkflowDefinition['name'];
+    isAllowed: WorkflowDefinition['isAllowed'];
     productName: ProductDefinition['name'];
     productId: ProductDefinition['productId'];
     productType: ProductDefinition['productType'];
@@ -44,6 +46,7 @@ type WorkflowOption = {
 
 type WorkflowOptionsResult = StartOptionsResult<{
     name: WorkflowDefinition['name'];
+    isAllowed: WorkflowDefinition['isAllowed'];
     products: {
         name: ProductDefinition['name'];
         productId: ProductDefinition['productId'];
@@ -75,9 +78,11 @@ const startButtonOptionsApi = orchestratorApi.injectEndpoints({
                 const workflows = response?.workflows?.page || [];
                 workflows.forEach((workflow) => {
                     const workflowName = workflow.name;
+                    const workflowIsAllowed = workflow.isAllowed;
                     workflow.products.forEach((product) => {
                         startOptions.push({
                             workflowName,
+                            isAllowed: workflowIsAllowed,
                             productName: product.name,
                             productId: product.productId,
                             productType: product.productType,

--- a/packages/orchestrator-ui-components/src/types/forms.ts
+++ b/packages/orchestrator-ui-components/src/types/forms.ts
@@ -40,5 +40,5 @@ export type FormValidationError = {
 
 export interface FormUserPermissions {
     retryAllowed: boolean;
-    inputAllowed: boolean;
+    resumeAllowed: boolean;
 }

--- a/packages/orchestrator-ui-components/src/types/forms.ts
+++ b/packages/orchestrator-ui-components/src/types/forms.ts
@@ -40,6 +40,5 @@ export type FormValidationError = {
 
 export interface FormUserPermissions {
     retryAllowed: boolean;
-    abortAllowed: boolean;
     inputAllowed: boolean;
 }

--- a/packages/orchestrator-ui-components/src/types/forms.ts
+++ b/packages/orchestrator-ui-components/src/types/forms.ts
@@ -37,3 +37,9 @@ export type FormValidationError = {
     data: ValidationErrorData;
     status: HttpStatus;
 };
+
+export interface FormUserPermissions {
+    retryAllowed: boolean;
+    abortAllowed: boolean;
+    inputAllowed: boolean;
+}

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 
-import { InputForm } from './forms';
+import { FormUserPermissions, InputForm } from './forms';
 
 export type Nullable<T> = T | null;
 
@@ -198,6 +198,7 @@ export interface ProcessDetail {
     isTask: boolean;
     steps: Step[];
     traceback: string | null;
+    userPermissions: FormUserPermissions;
     subscriptions: {
         page: {
             product: Pick<ProductDefinition, 'name'>;

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -264,6 +264,7 @@ export interface WorkflowDefinition {
     description: string;
     target: WorkflowTarget;
     isTask: boolean;
+    isAllowed: boolean;
     products: Pick<ProductDefinition, 'tag' | 'productId' | 'name'>[];
     createdAt: string;
 }
@@ -407,6 +408,7 @@ export type StartComboBoxOption = {
         productId?: string;
     };
     label: string;
+    disabled?: boolean;
 };
 
 export interface GraphQlResultPage<T> {

--- a/packages/orchestrator-ui-components/src/utils/getProductNamesFromProcess.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/getProductNamesFromProcess.spec.ts
@@ -14,7 +14,6 @@ const getProcessDetail = (data: Partial<ProcessDetail> = {}): ProcessDetail => {
         traceback: null,
         userPermissions: {
             retryAllowed: true,
-            abortAllowed: true,
             inputAllowed: true,
         },
         steps: [

--- a/packages/orchestrator-ui-components/src/utils/getProductNamesFromProcess.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/getProductNamesFromProcess.spec.ts
@@ -14,7 +14,7 @@ const getProcessDetail = (data: Partial<ProcessDetail> = {}): ProcessDetail => {
         traceback: null,
         userPermissions: {
             retryAllowed: true,
-            inputAllowed: true,
+            resumeAllowed: true,
         },
         steps: [
             {

--- a/packages/orchestrator-ui-components/src/utils/getProductNamesFromProcess.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/getProductNamesFromProcess.spec.ts
@@ -12,6 +12,11 @@ const getProcessDetail = (data: Partial<ProcessDetail> = {}): ProcessDetail => {
         workflowName: 'workflowName',
         isTask: false,
         traceback: null,
+        userPermissions: {
+            retryAllowed: true,
+            abortAllowed: true,
+            inputAllowed: true,
+        },
         steps: [
             {
                 name: 'step name',

--- a/version-compatibility.json
+++ b/version-compatibility.json
@@ -2,7 +2,7 @@
     {
         "orchestratorUiVersion": "5.3.5",
         "minimumOrchestratorCoreVersion": "4.2.0",
-        "changes": "Breaking Change on process.steps, using new props started and completed from graphql to improve the process detail timestamps."
+        "changes": "Endpoints in BE to support RBAC on individual running workflows and usage new graphql props started and completed to improve the process detail timestamps."
     },
     {
         "orchestratorUiVersion": "5.0.0",


### PR DESCRIPTION
Closes #2013 and #1730 
Depends on: https://github.com/workfloworchestrator/orchestrator-core/pull/990

Adds support for reflecting RBAC rules from the backend in the frontend. Depends on a backend update.

When a user lacks permission for an operation, buttons and input fields (if applicable) are grayed out



Unable to create specific products:
![image](https://github.com/user-attachments/assets/b9811038-f4be-458e-9dc9-3b0b073dca47)



Unable to start a specific task:
![image](https://github.com/user-attachments/assets/f588be4b-7abc-468c-88c9-edf2e320cf45)



Unable to resume a workflow:
![image](https://github.com/user-attachments/assets/c9779b30-26e8-4dea-9e8c-bf5bf9c7ac92)



Unable to run a specific workflow on a subscription:
![image](https://github.com/user-attachments/assets/eaa67ba9-c417-47b7-b0e0-de590f920e34)