### PR TITLE
Tweak settings modal margins

### DIFF
--- a/.changeset/common-zoos-mate.md
+++ b/.changeset/common-zoos-mate.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+223 Tweak spacing of columns in table settings modal

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableSettingsModal/WfoTableSettingsModal.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableSettingsModal/WfoTableSettingsModal.tsx
@@ -37,7 +37,8 @@ export const TableSettingsModal = <T,>({
   extraSettings,
 }: TableSettingsModalProps<T>) => {
   const t = useTranslations('main');
-  const { formRowStyle, columnsListStyle, selectFieldStyle } = useWithOrchestratorTheme(getWfoTableSettingsModalStyles);
+  const { formStyle, formRowStyle, columnsListStyle, selectFieldStyle } =
+    useWithOrchestratorTheme(getWfoTableSettingsModalStyles);
   const scrollBarStyle = useEuiScrollBar();
 
   const [columns, setColumns] = useState(tableConfig.columns);
@@ -72,7 +73,7 @@ export const TableSettingsModal = <T,>({
         })
       }
     >
-      <EuiForm>
+      <EuiForm css={formStyle}>
         <div css={[columnsListStyle, scrollBarStyle]}>
           {columns.map(({ field, name, isVisible }) => (
             <div key={field.toString()}>

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableSettingsModal/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoTableSettingsModal/styles.ts
@@ -14,6 +14,15 @@ export const getWfoTableSettingsModalStyles = (wfoThemeHelpers: WfoThemeHelpers)
     },
   });
 
+  const formStyle = css({
+    '.euiFormRow .euiFormRow__labelWrapper': {
+      flexBasis: '50%',
+    },
+    '.euiFormRow .euiFormRow__fieldWrapper': {
+      flexBasis: '50%',
+    },
+  });
+
   const { theme } = wfoThemeHelpers;
 
   const columnsListStyle = css({
@@ -30,6 +39,7 @@ export const getWfoTableSettingsModalStyles = (wfoThemeHelpers: WfoThemeHelpers)
   });
 
   return {
+    formStyle,
     formRowStyle,
     columnsListStyle,
     selectFieldStyle: formFieldBaseStyle,


### PR DESCRIPTION
<img width="870" height="1312" alt="Screenshot 2026-08-31 at 21 54 59" src="https://github.com/user-attachments/assets/8d7f418e-9827-427d-8744-547f664394d0" />

This prevented the dutch translation to show on a single row before.